### PR TITLE
fix: use uv in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ USER maverick
 EXPOSE 8000
 
 # Start MCP server
-CMD ["python", "-m", "maverick_mcp.api.server", "--transport", "sse", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "python", "-m", "maverick_mcp.api.server", "--transport", "sse", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Sorry to delete the PR template but I feel like they are too overwhelming and too much for such a simple fix.

I was trying to run

```
docker compose up -d
```

And got the following error

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/app/maverick_mcp/api/server.py", line 49, in <module>
    from fastmcp import FastMCP
ModuleNotFoundError: No module named 'fastmcp'
```

Found that `uv` was not used to start up the API which is should since all the dependencies are installed by uv