### PR TITLE
fix: register rate limiting middleware on FastAPI app instead of FastMCP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   backend:
     build: .
     ports:
-      - "8003:8003"
+      - "8003:8000"
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/maverick_mcp
       - REDIS_HOST=redis

--- a/maverick_mcp/api/server.py
+++ b/maverick_mcp/api/server.py
@@ -372,8 +372,14 @@ rate_limit_config = RateLimitConfig(
         int(settings.middleware.api_rate_limit_per_minute / 2), 1
     ),  # Analysis is more expensive
 )
-mcp.add_middleware(Middleware(EnhancedRateLimitMiddleware, config=rate_limit_config))
-logger.info("Enhanced Rate Limiting Middleware added to MCP server")
+# EnhancedRateLimitMiddleware is a Starlette ASGI middleware, so it must be added
+# to the FastAPI app (HTTP layer), not to the FastMCP instance (MCP protocol layer).
+# FastMCP's add_middleware expects fastmcp.server.middleware.Middleware subclasses.
+if hasattr(mcp, "fastapi_app") and mcp.fastapi_app:
+    mcp.fastapi_app.add_middleware(EnhancedRateLimitMiddleware, config=rate_limit_config)
+    logger.info("Enhanced Rate Limiting Middleware added to FastAPI application")
+else:
+    logger.warning("Rate limiting middleware not added (no FastAPI app available)")
 
 # Initialize enhanced health monitoring system
 logger.info("Initializing enhanced health monitoring system...")


### PR DESCRIPTION
## fix: register rate limiting middleware on FastAPI app instead of FastMCP

### Problem

Commit `36d57d5` ("Sentinel: Enable Enhanced Rate Limiting Middleware") introduced a bug that made the MCP server completely unusable. Every `tools/list` request returned:

```json
{"jsonrpc": "2.0", "id": 2, "error": {"code": 0, "message": "the first argument must be callable"}}
```

This meant no MCP client (Claude Code, Claude Desktop, MCP Inspector) could discover or use any of the server's 57 tools.

### Root Cause

`EnhancedRateLimitMiddleware` extends Starlette's `BaseHTTPMiddleware` — it operates at the HTTP transport layer, inspecting client IPs, classifying URL paths into rate limit tiers, and returning HTTP 429 responses.

Commit `36d57d5` registered it via:

```python
mcp.add_middleware(Middleware(EnhancedRateLimitMiddleware, config=rate_limit_config))
```

Here, `Middleware` is `starlette.middleware.Middleware` — a namedtuple that describes how to construct an ASGI middleware. But FastMCP's `add_middleware()` expects instances of `fastmcp.server.middleware.Middleware`, a base class with protocol-level hooks (`on_call_tool`, `on_list_tools`, etc.). These are two completely different types that happen to share the same name.

When FastMCP tried to invoke the Starlette `Middleware` namedtuple during `tools/list` processing, it failed because a namedtuple is not callable in the way FastMCP expects.

### Fix

Register the middleware on `mcp.fastapi_app` instead, which is the underlying FastAPI/Starlette HTTP application where this middleware was designed to operate:

```python
mcp.fastapi_app.add_middleware(EnhancedRateLimitMiddleware, config=rate_limit_config)
```

Also fixes `docker-compose.yml` port mapping: the Dockerfile CMD listens on port 8000, but the compose file mapped `8003:8003`. Changed to `8003:8000`.

## 📋 Pull Request Summary

**Brief description of changes:**
Fix broken rate limiting middleware registration that prevented all MCP tool discovery, and correct docker-compose port mapping.

**Related issue(s):**
- Fixes the regression introduced by `36d57d5` / PR #84

## 💰 Financial Disclaimer Acknowledgment

- [x] I understand this is educational software and not financial advice
- [x] Any financial analysis features include appropriate disclaimers
- [x] This PR maintains the educational/personal-use focus of the project

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🎯 Component Areas

**Primary areas affected:**
- [x] MCP server/tools implementation
- [x] Development tools and setup

## 🔧 Implementation Details

**Technical approach:**
Move the Starlette ASGI middleware from FastMCP's protocol-level middleware pipeline to the FastAPI HTTP application where it belongs. This is a one-line change in registration target — the middleware itself is unmodified.

**Key changes:**
- Changed `mcp.add_middleware(Middleware(...))` to `mcp.fastapi_app.add_middleware(...)` so the Starlette middleware is registered at the HTTP layer
- Added guard for when `fastapi_app` is not available (e.g. STDIO transport) with a warning log
- Fixed docker-compose.yml port mapping from `8003:8003` to `8003:8000` to match the Dockerfile CMD

**Dependencies:**
- [x] No new dependencies added

## 🧪 Testing

**Testing performed:**
- [x] Manual testing completed
- [x] Tested with Claude Desktop

**Test scenarios covered:**
- [x] Happy path functionality
- [x] Error handling and edge cases

**Manual testing:**
```bash
# Full MCP handshake via SSE confirming tools/list returns 57 tools:
python3 -c "
import urllib.request, json, time
resp = urllib.request.urlopen('http://localhost:8003/sse', timeout=15)
# ... initialize session, send tools/list ...
# Result: SUCCESS: 57 tools
"

# Standalone tool registration + listing (inside container):
docker compose exec backend uv run python3 -c "
from fastmcp import FastMCP
mcp = FastMCP('test')
from maverick_mcp.api.routers.tool_registry import register_all_router_tools
register_all_router_tools(mcp)
import asyncio
asyncio.run(mcp._list_tools())  # Tools count: 52
"
```

## 📊 Financial Analysis Impact

- [x] No financial calculations affected

## 🔒 Security Considerations

**Security checklist:**
- [x] No hardcoded secrets or credentials
- [x] Input validation implemented
- [x] Error handling doesn't leak sensitive information
- [x] API keys handled securely via environment variables
- [x] Rate limiting respected for external APIs

Rate limiting is now correctly active at the HTTP layer, restoring the intended security posture.

## 📚 Documentation

- [x] Code comments added/updated
- [x] No breaking changes

## ✅ Pre-submission Checklist

**Code quality:**
- [x] Self-review of code completed
- [x] No linting errors

## 🚀 Deployment Notes

- [x] No new environment variables needed
- [x] No database migrations required
- [x] Changes are fully backward compatible

**Docker users:** The `docker-compose.yml` port mapping changed from `8003:8003` to `8003:8000`. If you were using a `command:` override that sets `--port 8003`, this change doesn't affect you. If you rely on the Dockerfile's default CMD (`--port 8000`), this fix is required.

