### PR TITLE
docs: add Windows Claude Desktop configuration workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ This configuration provides stable tool registration and prevents tools from dis
 }
 ```
 
+> [!WARNING]
+> **Windows Claude Desktop Users**
+> Claude Desktop on Windows currently has a bug where it ignores the `"cwd"` configuration parameter, which can cause the server to crash with a `ModuleNotFoundError` when running via `uv`. 
+> 
+> To bypass this, wrap the command in `cmd.exe` to force the directory change:
+> ```json
+> "maverick-mcp": {
+>   "command": "cmd.exe",
+>   "args": [
+>     "/c",
+>     "cd /d C:\\Path\\To\\maverick-mcp && uv run python -m maverick_mcp.api.server --transport stdio"
+>   ]
+> }
+> ```
+
 > **Important**: Note the trailing slash in `/sse/` - this is REQUIRED to prevent redirect issues!
 
 **Config File Location:**


### PR DESCRIPTION
## PR Title:

docs: Add Windows Claude Desktop troubleshooting for cwd bug

## Description:

Why this update is needed
Currently, Windows users trying to run Maverick through Claude Desktop will encounter a crash (ModuleNotFoundError: No module named 'dotenv').

This is caused by an ongoing bug in the Windows version of Claude Desktop where it completely ignores the "cwd" parameter in the configuration file. Because it defaults the working directory to C:\WINDOWS\System32, running uv triggers a raw Python environment that cannot find the maverick-mcp project files.

## The Fix
This PR adds a warning block to the README.md specifically for Windows Claude Desktop users. It provides a tested workaround: wrapping the command in cmd.exe to forcefully alter the directory (cd /d) before triggering uv. This permanently bypasses the Claude Desktop bug and allows the server to initialize perfectly.