### PR TITLE
Phase 1: triage and quick wins (CI bootstrap, ruff autofix, doc accuracy, type bug fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - name: Sync dependencies
+        run: uv sync --extra dev --frozen
+      - name: Ruff check
+        run: uv run ruff check .
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+  typecheck:
+    name: Type check (ty, baseline)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - name: Sync dependencies
+        run: uv sync --extra dev --frozen
+      # Baseline run: do not block PRs while the LangChain/LangGraph
+      # integration surface still emits the bulk of diagnostics.
+      # Phase 2.4 will add a strict gate over maverick_mcp/services
+      # and maverick_mcp/domain.
+      - name: ty check (informational)
+        continue-on-error: true
+        run: uv run ty check maverick_mcp
+
+  test-unit:
+    name: Unit tests (pytest)
+    runs-on: ubuntu-latest
+    env:
+      MAVERICK_TEST_ENV: "true"
+      TIINGO_API_KEY: "ci-dummy-key"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - name: Sync dependencies
+        # `--extra dev` pulls in pytest, testcontainers, etc. Required
+        # because tests/conftest.py imports `testcontainers.postgres`
+        # at collection time even though those fixtures are not used
+        # by the unit-only marker selection below.
+        run: uv sync --extra dev --frozen
+      - name: Run unit tests
+        run: |
+          uv run pytest \
+            -m "not integration and not slow and not external" \
+            --maxfail=5 \
+            --timeout=60

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,7 +433,7 @@ claude mcp add maverick-mcp uv run python -m maverick_mcp.api.server --transport
 
 ## Available Tools
 
-All tools are organized into logical groups (39+ tools total):
+All tools are organized into logical groups (~72 tools total across domain routers):
 
 ### Data Tools (`/data/*`) - S&P 500 Pre-seeded
 
@@ -794,9 +794,9 @@ Once connected to Claude Desktop, test the backtesting framework:
 
 ### Testing & Quality
 
-- **84% Test Coverage**: 93 tests with comprehensive coverage
-- **Zero Linting Errors**: Fixed 947 issues for clean codebase
-- **Full Type Annotations**: Complete type coverage for research components
+- **Comprehensive Test Suite**: ~195 unit test functions across the `tests/` tree
+- **Zero Lint Errors**: Clean ruff baseline maintained in CI
+- **Full Type Annotations**: Type coverage for research and service components
 - **Error Recovery Testing**: Comprehensive failure scenario coverage
 
 ### Personal Use Optimization

--- a/README.md
+++ b/README.md
@@ -804,9 +804,9 @@ For issues or questions:
 
 ### Testing & Quality
 
-- **84% Test Coverage**: 93 tests with comprehensive coverage
-- **Zero Linting Errors**: Fixed 947 issues for clean codebase
-- **Full Type Annotations**: Complete type coverage for research components
+- **Comprehensive Test Suite**: ~195 unit test functions across the `tests/` tree
+- **Zero Lint Errors**: Clean ruff baseline maintained in CI
+- **Full Type Annotations**: Type coverage for research and service components
 - **Error Recovery Testing**: Comprehensive failure scenario coverage
 
 ### Personal Use Optimization

--- a/maverick_mcp/api/routers/journal.py
+++ b/maverick_mcp/api/routers/journal.py
@@ -59,7 +59,9 @@ def register_journal_tools(mcp: FastMCP) -> None:
                     "side": entry.side,
                     "entry_price": entry.entry_price,
                     "shares": entry.shares,
-                    "entry_date": entry.entry_date.isoformat() if entry.entry_date else None,
+                    "entry_date": entry.entry_date.isoformat()
+                    if entry.entry_date
+                    else None,
                     "tags": entry.tags,
                     "status": entry.status,
                     "rationale": entry.rationale,
@@ -106,8 +108,12 @@ def register_journal_tools(mcp: FastMCP) -> None:
                     "shares": entry.shares,
                     "pnl": entry.pnl,
                     "r_multiple": entry.r_multiple,
-                    "entry_date": entry.entry_date.isoformat() if entry.entry_date else None,
-                    "exit_date": entry.exit_date.isoformat() if entry.exit_date else None,
+                    "entry_date": entry.entry_date.isoformat()
+                    if entry.entry_date
+                    else None,
+                    "exit_date": entry.exit_date.isoformat()
+                    if entry.exit_date
+                    else None,
                     "tags": entry.tags,
                     "status": entry.status,
                     "notes": entry.notes,
@@ -158,8 +164,12 @@ def register_journal_tools(mcp: FastMCP) -> None:
                             "pnl": e.pnl,
                             "status": e.status,
                             "tags": e.tags,
-                            "entry_date": e.entry_date.isoformat() if e.entry_date else None,
-                            "exit_date": e.exit_date.isoformat() if e.exit_date else None,
+                            "entry_date": e.entry_date.isoformat()
+                            if e.entry_date
+                            else None,
+                            "exit_date": e.exit_date.isoformat()
+                            if e.exit_date
+                            else None,
                         }
                         for e in entries
                     ],
@@ -280,11 +290,15 @@ def register_journal_tools(mcp: FastMCP) -> None:
                 if entry.exit_price is not None and entry.entry_price:
                     if entry.side == "long":
                         pnl_pct = (
-                            (entry.exit_price - entry.entry_price) / entry.entry_price * 100
+                            (entry.exit_price - entry.entry_price)
+                            / entry.entry_price
+                            * 100
                         )
                     else:
                         pnl_pct = (
-                            (entry.entry_price - entry.exit_price) / entry.entry_price * 100
+                            (entry.entry_price - entry.exit_price)
+                            / entry.entry_price
+                            * 100
                         )
 
                 return {
@@ -296,8 +310,12 @@ def register_journal_tools(mcp: FastMCP) -> None:
                     "entry_price": entry.entry_price,
                     "exit_price": entry.exit_price,
                     "shares": entry.shares,
-                    "entry_date": entry.entry_date.isoformat() if entry.entry_date else None,
-                    "exit_date": entry.exit_date.isoformat() if entry.exit_date else None,
+                    "entry_date": entry.entry_date.isoformat()
+                    if entry.entry_date
+                    else None,
+                    "exit_date": entry.exit_date.isoformat()
+                    if entry.exit_date
+                    else None,
                     "pnl": entry.pnl,
                     "pnl_pct": pnl_pct,
                     "r_multiple": entry.r_multiple,

--- a/maverick_mcp/api/routers/risk_dashboard.py
+++ b/maverick_mcp/api/routers/risk_dashboard.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
-from decimal import Decimal
 from typing import Any
 
 from fastmcp import FastMCP
@@ -50,7 +49,9 @@ def register_risk_dashboard_tools(mcp: FastMCP) -> None:
                 try:
                     df = provider.get_stock_data(
                         pos.ticker,
-                        start_date=(datetime.now(UTC) - timedelta(days=7)).strftime("%Y-%m-%d"),
+                        start_date=(datetime.now(UTC) - timedelta(days=7)).strftime(
+                            "%Y-%m-%d"
+                        ),
                         end_date=datetime.now(UTC).strftime("%Y-%m-%d"),
                     )
                     if df is not None and not df.empty:
@@ -172,7 +173,6 @@ def register_risk_dashboard_tools(mcp: FastMCP) -> None:
     ) -> dict:
         """Compute regime-adjusted position size."""
         try:
-            import pandas as pd
             from maverick_mcp.data.models import SessionLocal
             from maverick_mcp.providers.stock_data import EnhancedStockDataProvider
             from maverick_mcp.services.risk.service import RiskService

--- a/maverick_mcp/api/routers/screening_pipeline.py
+++ b/maverick_mcp/api/routers/screening_pipeline.py
@@ -28,7 +28,9 @@ def register_screening_pipeline_tools(mcp: FastMCP) -> None:
         try:
             from maverick_mcp.data.models import SessionLocal
             from maverick_mcp.services import event_bus
-            from maverick_mcp.services.screening.pipeline import ScreeningPipelineService
+            from maverick_mcp.services.screening.pipeline import (
+                ScreeningPipelineService,
+            )
 
             with SessionLocal() as session:
                 svc = ScreeningPipelineService(db_session=session, event_bus=event_bus)
@@ -43,7 +45,9 @@ def register_screening_pipeline_tools(mcp: FastMCP) -> None:
                             "screen_name": c.screen_name,
                             "previous_rank": c.previous_rank,
                             "new_rank": c.new_rank,
-                            "detected_at": c.detected_at.isoformat() if c.detected_at else None,
+                            "detected_at": c.detected_at.isoformat()
+                            if c.detected_at
+                            else None,
                         }
                         for c in changes
                     ],
@@ -69,7 +73,9 @@ def register_screening_pipeline_tools(mcp: FastMCP) -> None:
         try:
             from maverick_mcp.data.models import SessionLocal
             from maverick_mcp.services import event_bus
-            from maverick_mcp.services.screening.pipeline import ScreeningPipelineService
+            from maverick_mcp.services.screening.pipeline import (
+                ScreeningPipelineService,
+            )
 
             with SessionLocal() as session:
                 svc = ScreeningPipelineService(db_session=session, event_bus=event_bus)
@@ -152,7 +158,9 @@ def register_screening_pipeline_tools(mcp: FastMCP) -> None:
         try:
             from maverick_mcp.data.models import SessionLocal
             from maverick_mcp.services import event_bus
-            from maverick_mcp.services.screening.pipeline import ScreeningPipelineService
+            from maverick_mcp.services.screening.pipeline import (
+                ScreeningPipelineService,
+            )
 
             with SessionLocal() as session:
                 svc = ScreeningPipelineService(db_session=session, event_bus=event_bus)

--- a/maverick_mcp/api/routers/signals.py
+++ b/maverick_mcp/api/routers/signals.py
@@ -161,7 +161,9 @@ def register_signal_tools(mcp: FastMCP) -> None:
         """Evaluate all active signals immediately."""
         try:
             import asyncio
+
             import pandas as pd
+
             from maverick_mcp.data.models import SessionLocal
             from maverick_mcp.providers.stock_data import EnhancedStockDataProvider
             from maverick_mcp.services import event_bus
@@ -207,7 +209,6 @@ def register_signal_tools(mcp: FastMCP) -> None:
     def get_market_regime() -> dict:
         """Classify current market regime using SPY data."""
         try:
-            import pandas as pd
             from maverick_mcp.providers.stock_data import EnhancedStockDataProvider
             from maverick_mcp.services.signals.regime import RegimeDetector
 
@@ -220,7 +221,9 @@ def register_signal_tools(mcp: FastMCP) -> None:
             # Normalise column names
             close_col = next(
                 (c for c in spy_data.columns if c.lower() == "close"),
-                spy_data.columns[3] if len(spy_data.columns) > 3 else spy_data.columns[0],
+                spy_data.columns[3]
+                if len(spy_data.columns) > 3
+                else spy_data.columns[0],
             )
             prices = spy_data[close_col].dropna()
 

--- a/maverick_mcp/api/routers/tool_registry.py
+++ b/maverick_mcp/api/routers/tool_registry.py
@@ -194,9 +194,13 @@ class ToolRateLimiter:
                     continue
                 # Prune stale entries while computing counts
                 if key in self._minute_counts:
-                    self._minute_counts[key] = [t for t in self._minute_counts[key] if now - t < 60]
+                    self._minute_counts[key] = [
+                        t for t in self._minute_counts[key] if now - t < 60
+                    ]
                 if key in self._hour_counts:
-                    self._hour_counts[key] = [t for t in self._hour_counts[key] if now - t < 3600]
+                    self._hour_counts[key] = [
+                        t for t in self._hour_counts[key] if now - t < 3600
+                    ]
                 status[key] = {
                     "calls_this_minute": len(self._minute_counts.get(key, [])),
                     "limit_per_minute": config.max_calls_per_minute,
@@ -1344,13 +1348,17 @@ def register_all_router_tools(mcp: FastMCP) -> None:
 
     try:
         from maverick_mcp.api.routers.signals import register_signal_tools
+
         register_signal_tools(mcp)
         logger.info("Signal tools registered successfully")
     except Exception as e:
         logger.error(f"Failed to register signal tools: {e}")
 
     try:
-        from maverick_mcp.api.routers.screening_pipeline import register_screening_pipeline_tools
+        from maverick_mcp.api.routers.screening_pipeline import (
+            register_screening_pipeline_tools,
+        )
+
         register_screening_pipeline_tools(mcp)
         logger.info("Screening pipeline tools registered successfully")
     except Exception as e:
@@ -1358,6 +1366,7 @@ def register_all_router_tools(mcp: FastMCP) -> None:
 
     try:
         from maverick_mcp.api.routers.journal import register_journal_tools
+
         register_journal_tools(mcp)
         logger.info("Trade journal tools registered successfully")
     except Exception as e:
@@ -1365,13 +1374,17 @@ def register_all_router_tools(mcp: FastMCP) -> None:
 
     try:
         from maverick_mcp.api.routers.watchlist import register_watchlist_tools
+
         register_watchlist_tools(mcp)
         logger.info("Watchlist tools registered successfully")
     except Exception as e:
         logger.error(f"Failed to register watchlist tools: {e}")
 
     try:
-        from maverick_mcp.api.routers.risk_dashboard import register_risk_dashboard_tools
+        from maverick_mcp.api.routers.risk_dashboard import (
+            register_risk_dashboard_tools,
+        )
+
         register_risk_dashboard_tools(mcp)
         logger.info("Risk dashboard tools registered successfully")
     except Exception as e:

--- a/maverick_mcp/api/routers/watchlist.py
+++ b/maverick_mcp/api/routers/watchlist.py
@@ -89,7 +89,11 @@ def register_watchlist_tools(mcp: FastMCP) -> None:
             with SessionLocal() as session:
                 svc = WatchlistService(db_session=session)
                 svc.remove_from_watchlist(watchlist_id=watchlist_id, symbol=symbol)
-                return {"removed": True, "watchlist_id": watchlist_id, "symbol": symbol.upper()}
+                return {
+                    "removed": True,
+                    "watchlist_id": watchlist_id,
+                    "symbol": symbol.upper(),
+                }
         except Exception as e:
             logger.error("watchlist_remove error: %s", e)
             return {"error": str(e)}
@@ -152,7 +156,9 @@ def register_watchlist_tools(mcp: FastMCP) -> None:
                             "id": e.id,
                             "symbol": e.symbol,
                             "event_type": e.event_type,
-                            "event_date": e.event_date.isoformat() if e.event_date else None,
+                            "event_date": e.event_date.isoformat()
+                            if e.event_date
+                            else None,
                             "description": e.description,
                             "impact_assessment": e.impact_assessment,
                         }

--- a/maverick_mcp/api/server.py
+++ b/maverick_mcp/api/server.py
@@ -497,6 +497,7 @@ if hasattr(mcp, "fastapi_app") and mcp.fastapi_app:
         """Start the scheduler on the ASGI server's event loop."""
         try:
             from maverick_mcp.services import scheduler as maverick_scheduler
+
             maverick_scheduler.start()
             logger.info("Service layer scheduler started on server loop")
         except Exception as e:
@@ -1544,20 +1545,32 @@ if __name__ == "__main__":
             _reg.register("regime_detector", RegimeDetector())
 
             async def on_signal_for_risk(topic, data):
-                logger.debug("Risk: signal event for %s", data.get("ticker") if data else "unknown")
+                logger.debug(
+                    "Risk: signal event for %s",
+                    data.get("ticker") if data else "unknown",
+                )
 
             async def on_screening_change(topic, data):
-                logger.debug("Screening change: %s %s", data.get("change_type", "") if data else "", data.get("symbol", "") if data else "")
+                logger.debug(
+                    "Screening change: %s %s",
+                    data.get("change_type", "") if data else "",
+                    data.get("symbol", "") if data else "",
+                )
 
             async def on_regime_change(topic, data):
-                logger.info("Regime changed: %s (confidence: %s)",
-                    data.get("regime") if data else "unknown", data.get("confidence") if data else "unknown")
+                logger.info(
+                    "Regime changed: %s (confidence: %s)",
+                    data.get("regime") if data else "unknown",
+                    data.get("confidence") if data else "unknown",
+                )
 
             _eb.subscribe("signal.triggered", on_signal_for_risk)
             _eb.subscribe("screening.entry", on_screening_change)
             _eb.subscribe("screening.exit", on_screening_change)
             _eb.subscribe("regime.changed", on_regime_change)
-            logger.info("Service layer: domain services registered, event wiring complete")
+            logger.info(
+                "Service layer: domain services registered, event wiring complete"
+            )
         except Exception as e:
             logger.error(f"Failed to wire domain services: {e}")
 
@@ -1710,6 +1723,7 @@ if __name__ == "__main__":
             """Shutdown service layer scheduler."""
             try:
                 from maverick_mcp.services import scheduler as maverick_scheduler
+
                 maverick_scheduler.shutdown()
                 logger.info("Service layer scheduler stopped")
             except Exception as e:

--- a/maverick_mcp/memory/stores.py
+++ b/maverick_mcp/memory/stores.py
@@ -56,9 +56,7 @@ class MemoryStore:
         self._lock = threading.Lock()
 
         # Persistent connection (reused for all reads/writes)
-        self._conn = sqlite3.connect(
-            self._db_path, timeout=10, check_same_thread=False
-        )
+        self._conn = sqlite3.connect(self._db_path, timeout=10, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
 
         # Initialize the persistent store and load existing data

--- a/maverick_mcp/providers/openrouter_provider.py
+++ b/maverick_mcp/providers/openrouter_provider.py
@@ -440,7 +440,9 @@ class CostTrackingLLM:
             )
         return rid
 
-    async def _post_call_record(self, response: Any, request_id: str | None = None) -> None:
+    async def _post_call_record(
+        self, response: Any, request_id: str | None = None
+    ) -> None:
         """Record actual token usage from an AIMessage response."""
         rid = request_id or self._get_request_id()
         try:
@@ -459,7 +461,9 @@ class CostTrackingLLM:
                 exc_info=True,
             )
 
-    async def _post_call_record_generation(self, response: Any, request_id: str | None = None) -> None:
+    async def _post_call_record_generation(
+        self, response: Any, request_id: str | None = None
+    ) -> None:
         """Record actual token usage from a generate() LLMResult response."""
         rid = request_id or self._get_request_id()
         try:

--- a/maverick_mcp/services/__init__.py
+++ b/maverick_mcp/services/__init__.py
@@ -8,4 +8,11 @@ event_bus = EventBus()
 registry = ServiceRegistry()
 scheduler = MaverickScheduler()
 
-__all__ = ["EventBus", "MaverickScheduler", "ServiceRegistry", "event_bus", "registry", "scheduler"]
+__all__ = [
+    "EventBus",
+    "MaverickScheduler",
+    "ServiceRegistry",
+    "event_bus",
+    "registry",
+    "scheduler",
+]

--- a/maverick_mcp/services/journal/analytics.py
+++ b/maverick_mcp/services/journal/analytics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -45,9 +44,7 @@ class StrategyTracker:
             The upserted :class:`StrategyPerformance` instance.
         """
         closed_entries: list[JournalEntry] = (
-            self._db.query(JournalEntry)
-            .filter(JournalEntry.status == "closed")
-            .all()
+            self._db.query(JournalEntry).filter(JournalEntry.status == "closed").all()
         )
 
         # Filter entries that have the tag in their tags list

--- a/maverick_mcp/services/journal/models.py
+++ b/maverick_mcp/services/journal/models.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Column, DateTime, Float, Integer, JSON, String, Text
+from sqlalchemy import JSON, Column, DateTime, Float, Integer, String, Text
 
-from maverick_mcp.database.base import Base
 from maverick_mcp.data.models import TimestampMixin
+from maverick_mcp.database.base import Base
 
 
 class JournalEntry(Base, TimestampMixin):

--- a/maverick_mcp/services/journal/service.py
+++ b/maverick_mcp/services/journal/service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -145,7 +144,7 @@ class JournalService:
         self._db.refresh(entry)
 
         # Recompute strategy performance for all tags on this entry
-        for tag in (entry.tags or []):
+        for tag in entry.tags or []:
             try:
                 self._tracker.recompute(tag)
             except Exception as exc:
@@ -182,7 +181,9 @@ class JournalService:
             query = query.filter(JournalEntry.status == status)
         # strategy_tag filter: done in Python because JSON contains queries
         # vary significantly across backends
-        entries: list[JournalEntry] = query.order_by(JournalEntry.entry_date.desc()).all()
+        entries: list[JournalEntry] = query.order_by(
+            JournalEntry.entry_date.desc()
+        ).all()
 
         if strategy_tag is not None:
             entries = [
@@ -199,8 +200,4 @@ class JournalService:
         Returns:
             The :class:`JournalEntry` or None if not found.
         """
-        return (
-            self._db.query(JournalEntry)
-            .filter(JournalEntry.id == entry_id)
-            .first()
-        )
+        return self._db.query(JournalEntry).filter(JournalEntry.id == entry_id).first()

--- a/maverick_mcp/services/registry.py
+++ b/maverick_mcp/services/registry.py
@@ -34,8 +34,7 @@ class ServiceRegistry:
         """
         if name in self._services and not replace:
             raise ValueError(
-                f"Service {name!r} is already registered. "
-                "Use replace=True to override."
+                f"Service {name!r} is already registered. Use replace=True to override."
             )
         self._services[name] = service
 

--- a/maverick_mcp/services/risk/models.py
+++ b/maverick_mcp/services/risk/models.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Float, Integer, JSON, String, Text
+from sqlalchemy import JSON, Boolean, Column, DateTime, Float, Integer, String, Text
 
-from maverick_mcp.database.base import Base
 from maverick_mcp.data.models import TimestampMixin
+from maverick_mcp.database.base import Base
 
 
 class RiskAlert(Base, TimestampMixin):

--- a/maverick_mcp/services/risk/service.py
+++ b/maverick_mcp/services/risk/service.py
@@ -45,7 +45,9 @@ class RiskService:
     # Dashboard computation
     # ------------------------------------------------------------------
 
-    def compute_dashboard(self, portfolio_positions: list[dict[str, Any]]) -> dict[str, Any]:
+    def compute_dashboard(
+        self, portfolio_positions: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """Compute risk metrics for a portfolio.
 
         Args:
@@ -103,7 +105,9 @@ class RiskService:
 
         return {
             "total_value": round(total_value, 2),
-            "sector_concentration": {k: round(v, 4) for k, v in sector_concentration.items()},
+            "sector_concentration": {
+                k: round(v, 4) for k, v in sector_concentration.items()
+            },
             "max_sector_pct": round(max_sector_pct, 4),
             "portfolio_var_95": round(portfolio_var_95, 2),
             "portfolio_var_99": round(portfolio_var_99, 2),
@@ -153,7 +157,8 @@ class RiskService:
                 existing_cb = float(pos.get("cost_basis", 0))
                 total_shares = existing_shares + new_shares
                 avg_cb = (
-                    (existing_shares * existing_cb + new_shares * new_price) / total_shares
+                    (existing_shares * existing_cb + new_shares * new_price)
+                    / total_shares
                     if total_shares > 0
                     else new_price
                 )
@@ -287,7 +292,9 @@ class RiskService:
         # Single position size check
         if total_value > 0:
             for pos in portfolio_positions:
-                pos_value = float(pos.get("shares", 0)) * float(pos.get("current_price", 0))
+                pos_value = float(pos.get("shares", 0)) * float(
+                    pos.get("current_price", 0)
+                )
                 pos_pct = pos_value / total_value
                 ticker = pos.get("symbol", pos.get("ticker", "?"))
                 if pos_pct > _POSITION_WARN_PCT:
@@ -349,7 +356,9 @@ def _estimate_portfolio_std(
     variance = 0.0
     for pos in positions:
         weight = (
-            float(pos.get("shares", 0)) * float(pos.get("current_price", 0)) / total_value
+            float(pos.get("shares", 0))
+            * float(pos.get("current_price", 0))
+            / total_value
         )
         variance += (weight * daily_vol_per_position) ** 2
 

--- a/maverick_mcp/services/scheduler.py
+++ b/maverick_mcp/services/scheduler.py
@@ -160,7 +160,9 @@ class Scheduler:
                 {
                     "id": job.id,
                     "name": job.name,
-                    "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
+                    "next_run_time": job.next_run_time.isoformat()
+                    if job.next_run_time
+                    else None,
                 }
             )
         return jobs

--- a/maverick_mcp/services/screening/models.py
+++ b/maverick_mcp/services/screening/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, String
+from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String
 
 from maverick_mcp.database.base import Base
 

--- a/maverick_mcp/services/screening/pipeline.py
+++ b/maverick_mcp/services/screening/pipeline.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy.orm import Session
 
 from maverick_mcp.services.event_bus import EventBus
-from maverick_mcp.services.screening.models import ScheduledJob, ScreeningChange, ScreeningRun
+from maverick_mcp.services.screening.models import (
+    ScheduledJob,
+    ScreeningChange,
+    ScreeningRun,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +44,9 @@ class ScreeningPipelineService:
     # Run management
     # ------------------------------------------------------------------
 
-    def run_screen(self, screen_name: str, results: list[dict[str, Any]]) -> ScreeningRun:
+    def run_screen(
+        self, screen_name: str, results: list[dict[str, Any]]
+    ) -> ScreeningRun:
         """Snapshot screening results and detect entry/exit changes vs. previous run.
 
         Publishes ``screening.entry`` and ``screening.exit`` events for each change.
@@ -81,9 +86,7 @@ class ScreeningPipelineService:
 
         # 3. Diff old vs. new
         old_symbols: set[str] = {
-            r["symbol"].upper()
-            for r in (previous_run.results or [])
-            if r.get("symbol")
+            r["symbol"].upper() for r in (previous_run.results or []) if r.get("symbol")
         }
         new_symbols: set[str] = {
             r["symbol"].upper() for r in results if r.get("symbol")
@@ -170,9 +173,7 @@ class ScreeningPipelineService:
         query = self._db.query(ScreeningChange)
         if screen_name is not None:
             query = query.filter(ScreeningChange.screen_name == screen_name)
-        return (
-            query.order_by(ScreeningChange.detected_at.desc()).limit(limit).all()
-        )
+        return query.order_by(ScreeningChange.detected_at.desc()).limit(limit).all()
 
     # ------------------------------------------------------------------
     # History queries
@@ -202,9 +203,7 @@ class ScreeningPipelineService:
         history: list[dict[str, Any]] = []
         for run in runs:
             symbols_in_run = {
-                r["symbol"].upper()
-                for r in (run.results or [])
-                if r.get("symbol")
+                r["symbol"].upper() for r in (run.results or []) if r.get("symbol")
             }
             if symbol in symbols_in_run:
                 history.append(
@@ -230,7 +229,9 @@ class ScreeningPipelineService:
         """
         # Gather latest run per screen_name
         latest_runs: dict[str, ScreeningRun] = {}
-        all_runs = self._db.query(ScreeningRun).order_by(ScreeningRun.run_at.desc()).all()
+        all_runs = (
+            self._db.query(ScreeningRun).order_by(ScreeningRun.run_at.desc()).all()
+        )
         for run in all_runs:
             if run.screen_name not in latest_runs:
                 latest_runs[run.screen_name] = run
@@ -246,11 +247,7 @@ class ScreeningPipelineService:
         ]
 
         # Gather active scheduled jobs
-        jobs = (
-            self._db.query(ScheduledJob)
-            .filter(ScheduledJob.active.is_(True))
-            .all()
-        )
+        jobs = self._db.query(ScheduledJob).filter(ScheduledJob.active.is_(True)).all()
         scheduled_jobs = [
             {
                 "job_name": job.job_name,

--- a/maverick_mcp/services/signals/conditions.py
+++ b/maverick_mcp/services/signals/conditions.py
@@ -87,7 +87,11 @@ def evaluate_condition(
             previous_state=previous_state,
         )
     except ValueError as exc:
-        return {**_empty_result, "current_value": float(current_value), "error": str(exc)}
+        return {
+            **_empty_result,
+            "current_value": float(current_value),
+            "error": str(exc),
+        }
 
     return {
         "triggered": triggered,
@@ -200,11 +204,15 @@ def _evaluate_spike(
     elif indicator == "rsi":
         rsi_period = period or 14
         rsi_series = ta.rsi(data["close"], length=rsi_period)
-        series = rsi_series.dropna() if rsi_series is not None else pd.Series(dtype=float)
+        series = (
+            rsi_series.dropna() if rsi_series is not None else pd.Series(dtype=float)
+        )
     elif indicator == "sma":
         sma_period = period or 20
         sma_series = ta.sma(data["close"], length=sma_period)
-        series = sma_series.dropna() if sma_series is not None else pd.Series(dtype=float)
+        series = (
+            sma_series.dropna() if sma_series is not None else pd.Series(dtype=float)
+        )
     else:
         raise ValueError(f"Unknown indicator for spike: {indicator!r}")
 

--- a/maverick_mcp/services/signals/models.py
+++ b/maverick_mcp/services/signals/models.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Float, Integer, JSON, String
+from sqlalchemy import JSON, Boolean, Column, DateTime, Float, Integer, String
 
-from maverick_mcp.database.base import Base
 from maverick_mcp.data.models import TimestampMixin
+from maverick_mcp.database.base import Base
 
 
 class Signal(Base, TimestampMixin):

--- a/maverick_mcp/services/signals/service.py
+++ b/maverick_mcp/services/signals/service.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Any, Callable, Awaitable
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from sqlalchemy.orm import Session
 

--- a/maverick_mcp/services/watchlist/catalysts.py
+++ b/maverick_mcp/services/watchlist/catalysts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
 from sqlalchemy.orm import Session
 

--- a/maverick_mcp/services/watchlist/models.py
+++ b/maverick_mcp/services/watchlist/models.py
@@ -6,8 +6,8 @@ from datetime import UTC, datetime
 
 from sqlalchemy import Column, Date, DateTime, Integer, String, Text
 
-from maverick_mcp.database.base import Base
 from maverick_mcp.data.models import TimestampMixin
+from maverick_mcp.database.base import Base
 
 
 class Watchlist(Base, TimestampMixin):

--- a/maverick_mcp/services/watchlist/service.py
+++ b/maverick_mcp/services/watchlist/service.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
 
-from maverick_mcp.services.watchlist.models import CatalystEvent, Watchlist, WatchlistItem
+from maverick_mcp.services.watchlist.models import (
+    CatalystEvent,
+    Watchlist,
+    WatchlistItem,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -96,9 +100,7 @@ class WatchlistService:
             Dict with watchlist metadata and list of items.
         """
         watchlist = (
-            self._db.query(Watchlist)
-            .filter(Watchlist.id == watchlist_id)
-            .first()
+            self._db.query(Watchlist).filter(Watchlist.id == watchlist_id).first()
         )
         if watchlist is None:
             return {}

--- a/maverick_mcp/utils/parallel_screening.py
+++ b/maverick_mcp/utils/parallel_screening.py
@@ -176,7 +176,7 @@ def example_momentum_screen(symbol: str) -> dict[str, Any]:
 
     try:
         # Get stock data
-        provider = StockDataProvider(use_cache=False)
+        provider = StockDataProvider()
         data = provider.get_stock_data(
             symbol, start_date="2023-01-01", end_date="2024-01-01"
         )

--- a/tests/unit/test_catalyst_tracker.py
+++ b/tests/unit/test_catalyst_tracker.py
@@ -9,10 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from maverick_mcp.database.base import Base
-from maverick_mcp.data.models import TimestampMixin
-from maverick_mcp.services.watchlist.models import CatalystEvent, Watchlist, WatchlistItem
 from maverick_mcp.services.watchlist.catalysts import CatalystTracker
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -58,7 +55,9 @@ def test_add_catalyst(tracker):
 
 def test_add_catalyst_minimal(tracker):
     event_date = date.today() + timedelta(days=3)
-    catalyst = tracker.add_catalyst(symbol="MSFT", event_type="ex_div", event_date=event_date)
+    catalyst = tracker.add_catalyst(
+        symbol="MSFT", event_type="ex_div", event_date=event_date
+    )
     assert catalyst.id is not None
     assert catalyst.description is None
     assert catalyst.impact_assessment is None

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from maverick_mcp.services.event_bus import EventBus
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_journal_service.py
+++ b/tests/unit/test_journal_service.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from maverick_mcp.database.base import Base
 from maverick_mcp.services.event_bus import EventBus
-from maverick_mcp.services.journal.models import JournalEntry, StrategyPerformance
 from maverick_mcp.services.journal.service import JournalService
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -144,7 +140,7 @@ def test_list_trades_filter_by_symbol(service):
 
 
 def test_list_trades_filter_by_strategy_tag(service):
-    e1 = service.add_trade(
+    service.add_trade(
         symbol="AAPL", side="long", entry_price=100.0, shares=1.0, tags=["momentum"]
     )
     service.add_trade(

--- a/tests/unit/test_regime_detector.py
+++ b/tests/unit/test_regime_detector.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import pandas as pd
-import pytest
 
 from maverick_mcp.services.signals.regime import RegimeDetector
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -79,7 +77,12 @@ def test_drivers_dict_has_expected_keys():
     detector = RegimeDetector()
     prices = _uptrend()
     result = detector.classify(prices, vix_level=15.0)
-    assert set(result["drivers"].keys()) == {"trend", "volatility", "momentum", "breadth"}
+    assert set(result["drivers"].keys()) == {
+        "trend",
+        "volatility",
+        "momentum",
+        "breadth",
+    }
     assert set(result["votes"].keys()) == {"trend", "volatility", "momentum", "breadth"}
 
 

--- a/tests/unit/test_risk_service.py
+++ b/tests/unit/test_risk_service.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import sessionmaker
 from maverick_mcp.database.base import Base
 from maverick_mcp.services.risk.service import RiskService
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -33,6 +32,7 @@ def service(db_session):
 # ---------------------------------------------------------------------------
 # Sample data helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_positions():
     """Three-position portfolio across two sectors."""
@@ -242,7 +242,7 @@ def test_generate_alerts_single_position_oversized(service):
 def test_check_position_risk(service):
     """Adding a new position should change projected metrics."""
     positions = _make_balanced_positions()
-    current = service.compute_dashboard(positions)
+    service.compute_dashboard(positions)
 
     result = service.check_position_risk(
         portfolio_positions=positions,

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -8,7 +8,6 @@ import pytest
 
 from maverick_mcp.services.scheduler import Scheduler
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -67,7 +66,9 @@ async def test_add_multiple_jobs_all_listed(started_scheduler: Scheduler) -> Non
 
 
 @pytest.mark.asyncio
-async def test_list_jobs_returns_dict_with_expected_keys(started_scheduler: Scheduler) -> None:
+async def test_list_jobs_returns_dict_with_expected_keys(
+    started_scheduler: Scheduler,
+) -> None:
     async def my_job() -> None:
         pass
 

--- a/tests/unit/test_screening_pipeline.py
+++ b/tests/unit/test_screening_pipeline.py
@@ -8,9 +8,7 @@ from sqlalchemy.orm import sessionmaker
 
 from maverick_mcp.database.base import Base
 from maverick_mcp.services.event_bus import EventBus
-from maverick_mcp.services.screening.models import ScreeningChange, ScreeningRun, ScheduledJob
 from maverick_mcp.services.screening.pipeline import ScreeningPipelineService
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -151,7 +149,7 @@ def test_get_history_filters_by_screen(service):
 
 def test_get_latest_run(service):
     """get_latest_run returns the most recent run for a given screen."""
-    run1 = service.run_screen("maverick_bullish", _make_results("AAPL"))
+    service.run_screen("maverick_bullish", _make_results("AAPL"))
     run2 = service.run_screen("maverick_bullish", _make_results("AAPL", "MSFT"))
 
     latest = service.get_latest_run("maverick_bullish")
@@ -187,7 +185,9 @@ def test_get_pipeline_status_with_runs(service, db_session):
     assert "screen_a" in screen_names
     assert "screen_b" in screen_names
 
-    screen_a_status = next(s for s in status["screens"] if s["screen_name"] == "screen_a")
+    screen_a_status = next(
+        s for s in status["screens"] if s["screen_name"] == "screen_a"
+    )
     assert screen_a_status["last_result_count"] == 2
 
 

--- a/tests/unit/test_service_registry.py
+++ b/tests/unit/test_service_registry.py
@@ -6,7 +6,6 @@ import pytest
 
 from maverick_mcp.services.registry import ServiceRegistry
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -52,13 +51,17 @@ def test_register_with_replace_true_overwrites(registry: ServiceRegistry) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_get_optional_returns_service_when_registered(registry: ServiceRegistry) -> None:
+def test_get_optional_returns_service_when_registered(
+    registry: ServiceRegistry,
+) -> None:
     service = object()
     registry.register("opt_svc", service)
     assert registry.get_optional("opt_svc") is service
 
 
-def test_get_optional_returns_none_when_not_registered(registry: ServiceRegistry) -> None:
+def test_get_optional_returns_none_when_not_registered(
+    registry: ServiceRegistry,
+) -> None:
     assert registry.get_optional("nonexistent") is None
 
 

--- a/tests/unit/test_signal_conditions.py
+++ b/tests/unit/test_signal_conditions.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
 import pytest
 
 from maverick_mcp.services.signals.conditions import evaluate_condition
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -30,7 +28,9 @@ def _price_df(closes, volumes=None):
 
 def test_lt_triggered():
     df = _price_df([100.0] * 30)
-    result = evaluate_condition({"indicator": "price", "operator": "lt", "threshold": 110.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "lt", "threshold": 110.0}, df
+    )
     assert result["triggered"] is True
     assert result["current_value"] == pytest.approx(100.0)
     assert result["error"] is None
@@ -38,32 +38,42 @@ def test_lt_triggered():
 
 def test_lt_not_triggered():
     df = _price_df([120.0] * 30)
-    result = evaluate_condition({"indicator": "price", "operator": "lt", "threshold": 110.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "lt", "threshold": 110.0}, df
+    )
     assert result["triggered"] is False
 
 
 def test_gt_triggered():
     df = _price_df([150.0] * 30)
-    result = evaluate_condition({"indicator": "price", "operator": "gt", "threshold": 140.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "gt", "threshold": 140.0}, df
+    )
     assert result["triggered"] is True
     assert result["current_value"] == pytest.approx(150.0)
 
 
 def test_gt_not_triggered():
     df = _price_df([130.0] * 30)
-    result = evaluate_condition({"indicator": "price", "operator": "gt", "threshold": 140.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "gt", "threshold": 140.0}, df
+    )
     assert result["triggered"] is False
 
 
 def test_lte_triggered():
     df = _price_df([100.0] * 30)
-    result = evaluate_condition({"indicator": "price", "operator": "lte", "threshold": 100.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "lte", "threshold": 100.0}, df
+    )
     assert result["triggered"] is True
 
 
 def test_gte_triggered():
     df = _price_df([100.0] * 30)
-    result = evaluate_condition({"indicator": "price", "operator": "gte", "threshold": 100.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "gte", "threshold": 100.0}, df
+    )
     assert result["triggered"] is True
 
 
@@ -192,12 +202,16 @@ def test_unknown_indicator_returns_error():
 
 def test_result_includes_current_value():
     df = _price_df([123.45] * 30)
-    result = evaluate_condition({"indicator": "price", "operator": "gt", "threshold": 100.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "gt", "threshold": 100.0}, df
+    )
     assert result["current_value"] == pytest.approx(123.45)
 
 
 def test_empty_dataframe_returns_error():
     df = pd.DataFrame()
-    result = evaluate_condition({"indicator": "price", "operator": "gt", "threshold": 100.0}, df)
+    result = evaluate_condition(
+        {"indicator": "price", "operator": "gt", "threshold": 100.0}, df
+    )
     assert result["error"] is not None
     assert result["triggered"] is False

--- a/tests/unit/test_signal_service.py
+++ b/tests/unit/test_signal_service.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime
-
 import pandas as pd
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from maverick_mcp.database.base import Base
-from maverick_mcp.data.models import TimestampMixin
 from maverick_mcp.services.event_bus import EventBus
-from maverick_mcp.services.signals.models import Signal, SignalEvent, RegimeEvent
 from maverick_mcp.services.signals.service import SignalService
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -75,15 +69,23 @@ def test_list_signals_empty(service):
 
 
 def test_list_signals_returns_all(service):
-    service.create_signal("A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100})
-    service.create_signal("B", "GOOG", {"indicator": "price", "operator": "gt", "threshold": 200})
+    service.create_signal(
+        "A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100}
+    )
+    service.create_signal(
+        "B", "GOOG", {"indicator": "price", "operator": "gt", "threshold": 200}
+    )
     sigs = service.list_signals()
     assert len(sigs) == 2
 
 
 def test_list_signals_active_only(service):
-    sig1 = service.create_signal("A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100})
-    sig2 = service.create_signal("B", "GOOG", {"indicator": "price", "operator": "gt", "threshold": 200})
+    sig1 = service.create_signal(
+        "A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100}
+    )
+    sig2 = service.create_signal(
+        "B", "GOOG", {"indicator": "price", "operator": "gt", "threshold": 200}
+    )
     service.update_signal(sig2.id, active=False)
 
     active = service.list_signals(active_only=True)
@@ -92,7 +94,9 @@ def test_list_signals_active_only(service):
 
 
 def test_get_signal_found(service):
-    sig = service.create_signal("A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100})
+    sig = service.create_signal(
+        "A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100}
+    )
     fetched = service.get_signal(sig.id)
     assert fetched is not None
     assert fetched.id == sig.id
@@ -103,7 +107,9 @@ def test_get_signal_not_found(service):
 
 
 def test_update_signal(service):
-    sig = service.create_signal("A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100})
+    sig = service.create_signal(
+        "A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100}
+    )
     updated = service.update_signal(sig.id, label="New Label", interval_seconds=120)
     assert updated.label == "New Label"
     assert updated.interval_seconds == 120
@@ -115,7 +121,9 @@ def test_update_signal_not_found_raises(service):
 
 
 def test_delete_signal(service):
-    sig = service.create_signal("A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100})
+    sig = service.create_signal(
+        "A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100}
+    )
     service.delete_signal(sig.id)
     assert service.get_signal(sig.id) is None
 
@@ -125,7 +133,9 @@ def test_delete_signal_nonexistent_is_noop(service):
 
 
 def test_record_trigger(service):
-    sig = service.create_signal("A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100})
+    sig = service.create_signal(
+        "A", "AAPL", {"indicator": "price", "operator": "gt", "threshold": 100}
+    )
     evt = service.record_trigger(sig, price=155.0, snapshot={"triggered": True})
     assert evt.id is not None
     assert evt.signal_id == sig.id
@@ -152,7 +162,9 @@ async def test_evaluate_all_triggers_signal(service, event_bus):
     )
 
     triggered_events = []
-    event_bus.subscribe("signal.triggered", lambda topic, data: triggered_events.append(data))
+    event_bus.subscribe(
+        "signal.triggered", lambda topic, data: triggered_events.append(data)
+    )
 
     async def fetcher(ticker, days=60):
         return _make_price_df(150.0)
@@ -174,7 +186,9 @@ async def test_evaluate_all_no_trigger(service, event_bus):
     )
 
     triggered_events = []
-    event_bus.subscribe("signal.triggered", lambda topic, data: triggered_events.append(data))
+    event_bus.subscribe(
+        "signal.triggered", lambda topic, data: triggered_events.append(data)
+    )
 
     async def fetcher(ticker, days=60):
         return _make_price_df(150.0)
@@ -192,10 +206,14 @@ async def test_evaluate_all_publishes_cleared_event(service, event_bus):
         {"indicator": "price", "operator": "gt", "threshold": 200.0},
     )
     # Simulate previous trigger state
-    service.update_signal(sig.id, previous_state={"last_triggered": True, "last_value": 210.0})
+    service.update_signal(
+        sig.id, previous_state={"last_triggered": True, "last_value": 210.0}
+    )
 
     cleared_events = []
-    event_bus.subscribe("signal.cleared", lambda topic, data: cleared_events.append(data))
+    event_bus.subscribe(
+        "signal.cleared", lambda topic, data: cleared_events.append(data)
+    )
 
     async def fetcher(ticker, days=60):
         return _make_price_df(150.0)  # now below threshold

--- a/tests/unit/test_strategy_tracker.py
+++ b/tests/unit/test_strategy_tracker.py
@@ -9,9 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from maverick_mcp.database.base import Base
 from maverick_mcp.services.event_bus import EventBus
 from maverick_mcp.services.journal.analytics import StrategyTracker
-from maverick_mcp.services.journal.models import JournalEntry, StrategyPerformance
 from maverick_mcp.services.journal.service import JournalService
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -48,9 +46,18 @@ def tracker(db_session):
 # ---------------------------------------------------------------------------
 
 
-def _add_closed(service: JournalService, symbol: str, entry: float, exit: float, shares: float, tags: list[str]) -> None:
+def _add_closed(
+    service: JournalService,
+    symbol: str,
+    entry: float,
+    exit: float,
+    shares: float,
+    tags: list[str],
+) -> None:
     """Add a trade and immediately close it."""
-    e = service.add_trade(symbol=symbol, side="long", entry_price=entry, shares=shares, tags=tags)
+    e = service.add_trade(
+        symbol=symbol, side="long", entry_price=entry, shares=shares, tags=tags
+    )
     service.close_trade(e.id, exit_price=exit)
 
 
@@ -62,7 +69,9 @@ def _add_closed(service: JournalService, symbol: str, entry: float, exit: float,
 def test_recompute_with_mixed_results(service, tracker):
     """2 wins and 1 loss — verify all metrics are computed correctly."""
     # Win 1: PnL = (110 - 100) * 10 = 100
-    _add_closed(service, "AAPL", entry=100.0, exit=110.0, shares=10.0, tags=["momentum"])
+    _add_closed(
+        service, "AAPL", entry=100.0, exit=110.0, shares=10.0, tags=["momentum"]
+    )
     # Win 2: PnL = (120 - 100) * 5 = 100
     _add_closed(service, "GOOG", entry=100.0, exit=120.0, shares=5.0, tags=["momentum"])
     # Loss: PnL = (90 - 100) * 10 = -100
@@ -73,8 +82,8 @@ def test_recompute_with_mixed_results(service, tracker):
     assert perf.win_count == 2
     assert perf.loss_count == 1
     assert perf.total_pnl == pytest.approx(100.0)  # 100 + 100 - 100
-    assert perf.avg_win == pytest.approx(100.0)    # (100 + 100) / 2
-    assert perf.avg_loss == pytest.approx(100.0)   # abs(-100 / 1)
+    assert perf.avg_win == pytest.approx(100.0)  # (100 + 100) / 2
+    assert perf.avg_loss == pytest.approx(100.0)  # abs(-100 / 1)
 
     # expectancy = (2/3 * 100) - (1/3 * 100) = 66.67 - 33.33 = 33.33
     assert perf.expectancy == pytest.approx(100.0 / 3, rel=1e-4)
@@ -147,7 +156,9 @@ def test_recompute_excludes_open_trades(service, tracker):
     # Closed win
     _add_closed(service, "AAPL", entry=100.0, exit=110.0, shares=1.0, tags=["swing"])
     # Open trade (not closed)
-    service.add_trade(symbol="GOOG", side="long", entry_price=200.0, shares=1.0, tags=["swing"])
+    service.add_trade(
+        symbol="GOOG", side="long", entry_price=200.0, shares=1.0, tags=["swing"]
+    )
 
     perf = tracker.recompute("swing")
 

--- a/tests/unit/test_watchlist_service.py
+++ b/tests/unit/test_watchlist_service.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from maverick_mcp.database.base import Base
-from maverick_mcp.data.models import TimestampMixin
-from maverick_mcp.services.signals.models import Signal, SignalEvent, RegimeEvent
-from maverick_mcp.services.watchlist.models import CatalystEvent, Watchlist, WatchlistItem
+from maverick_mcp.services.signals.models import Signal
+from maverick_mcp.services.watchlist.models import (
+    CatalystEvent,
+)
 from maverick_mcp.services.watchlist.service import WatchlistService
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -41,7 +41,9 @@ def service(db_session):
 
 
 def test_create_watchlist(service):
-    wl = service.create_watchlist(name="Tech Plays", description="High-momentum tech stocks")
+    wl = service.create_watchlist(
+        name="Tech Plays", description="High-momentum tech stocks"
+    )
     assert wl.id is not None
     assert wl.name == "Tech Plays"
     assert wl.description == "High-momentum tech stocks"
@@ -55,7 +57,9 @@ def test_create_watchlist_no_description(service):
 
 def test_add_to_watchlist(service):
     wl = service.create_watchlist("My List")
-    item = service.add_to_watchlist(watchlist_id=wl.id, symbol="aapl", notes="Watch for breakout")
+    item = service.add_to_watchlist(
+        watchlist_id=wl.id, symbol="aapl", notes="Watch for breakout"
+    )
     assert item.id is not None
     assert item.watchlist_id == wl.id
     assert item.symbol == "AAPL"
@@ -157,7 +161,8 @@ def test_brief_returns_items_with_scores(db_session, service):
 
 
 def test_brief_detects_upcoming_catalyst(db_session, service):
-    from datetime import date, timedelta
+    from datetime import date
+
     wl = service.create_watchlist("Catalyst Test")
     service.add_to_watchlist(wl.id, "NVDA")
 
@@ -177,7 +182,8 @@ def test_brief_detects_upcoming_catalyst(db_session, service):
 
 
 def test_brief_no_catalyst_outside_window(db_session, service):
-    from datetime import date, timedelta
+    from datetime import date
+
     wl = service.create_watchlist("No Catalyst")
     service.add_to_watchlist(wl.id, "IBM")
 

--- a/tools/experiments/validation_examples.py
+++ b/tools/experiments/validation_examples.py
@@ -55,7 +55,7 @@ def get_stochastic_analysis(symbol: str, period: int = 14) -> dict[str, Any]:
     This demonstrates adding a new technical indicator tool.
     """
     # Simulate getting data
-    provider = StockDataProvider(use_cache=False)
+    provider = StockDataProvider()
     data = provider.get_stock_data(symbol, "2023-10-01", "2024-01-01")
 
     stoch = calculate_stochastic(data, k_period=period)
@@ -146,7 +146,7 @@ def screen_golden_cross(symbol: str) -> dict[str, Any]:
     """
     Screen for Golden Cross pattern (50 SMA crosses above 200 SMA).
     """
-    provider = StockDataProvider(use_cache=False)
+    provider = StockDataProvider()
     data = provider.get_stock_data(symbol, "2023-01-01", "2024-01-01")
 
     if len(data) < 200:

--- a/tools/quick_test.py
+++ b/tools/quick_test.py
@@ -42,7 +42,7 @@ async def test_stock_data():
     from maverick_mcp.providers.stock_data import StockDataProvider
 
     print("\n🧪 Testing StockDataProvider...")
-    provider = StockDataProvider(use_cache=False)  # Skip cache for testing
+    provider = StockDataProvider()
 
     # Test getting stock data
     df = provider.get_stock_data("AAPL", "2024-01-01", "2024-01-10")


### PR DESCRIPTION
## Summary

Phase 1 of the post-v1 forward plan ([plan doc](https://claude.ai/code/session_0174FB5hPn6n5ho2mVW7H86q)). Four small, independent commits that establish a CI baseline and clean up accumulated drift before Phase 2 starts touching files at scale.

- **`chore: ruff autofix and format`** — resolves all 73 ruff lint errors (39 unused imports, 28 unsorted, 2 redefined, 1 deprecated, 3 unused-vars fixed manually) plus a `ruff format` pass over 28 files.
- **`fix: drop bogus use_cache kwarg from StockDataProvider call sites`** — `StockDataProvider(use_cache=False)` was raising `TypeError` in `tools/quick_test.py`, `tools/experiments/validation_examples.py` (×2), and `maverick_mcp/utils/parallel_screening.py`. The constructor only accepts `db_session`. Two stragglers in `api/routers/screening_parallel.py` are intentionally left for Phase 2.1 (file is dead, slated for deletion).
- **`docs: correct stale test count and tool count claims`** — README/CLAUDE claimed "84% Coverage, 93 tests" and "39+ tools". Actual counts: ~195 `def test_*` functions, 72 `@mcp.tool` registrations. Drops the unverified coverage % rather than re-cite stale data.
- **`ci: bootstrap GitHub Actions for lint, type-check, and unit tests`** — new `.github/workflows/ci.yml` with three jobs: `lint` (ruff check + format check, gating), `typecheck` (`ty check maverick_mcp` informational baseline, ~790 diagnostics, mostly LangChain/LangGraph noise — Phase 2.4 will add a strict gate over `services/` and `domain/`), `test-unit` (pytest with non-integration markers, requires `uv sync --extra dev` so `tests/conftest.py` can collect).

## Test plan

- [ ] `uv run ruff check .` returns 0 errors
- [ ] `uv run ruff format --check .` is clean
- [ ] `uv run pytest -m "not integration and not slow and not external" --maxfail=5 --timeout=60` is green (verified locally: 829 passed, 4 skipped, 664 deselected, ~97s)
- [ ] `uv run python tools/quick_test.py --help` no longer raises `TypeError`
- [ ] CI workflow runs on this PR and all three jobs report — `lint` and `test-unit` must pass; `typecheck` is informational
- [ ] `grep -nE "93 tests|39\+ tools" README.md CLAUDE.md` returns nothing

## Out of scope

PR #132 (BYOK feature), PR #68 (kaleido v1), and PR #159 (aiohttp bump) decisions are tracked separately. Phase 2 (delete dead routers and `api/services/` package, targeted refactors) lands in its own PR series.