### PR TITLE
Phase 3.1 follow-up + strict-zone burndown + v2 roadmap stub

### DIFF
--- a/docs/superpowers/plans/2026-Q3-maverick-roadmap-v2.md
+++ b/docs/superpowers/plans/2026-Q3-maverick-roadmap-v2.md
@@ -1,0 +1,95 @@
+# Maverick MCP Roadmap v2 — Stubs (post-v1, post-Phase-3.1/3.2)
+
+> **Status:** Stub. Each section is a paragraph, not a plan. The goal
+> is to start the next planning session warm rather than cold.
+
+## Context
+
+Roadmap v1 (`docs/superpowers/plans/2026-03-27-maverick-roadmap-v1.md`)
+shipped through April 2026: service-layer infrastructure (`event_bus`,
+`registry`, `scheduler`) plus all five domains
+(`signals`, `screening`, `journal`, `watchlist`, `risk`).
+
+The post-v1 forward plan (this directory's session at
+`/Users/wshobson/.claude/plans/read-in-any-roadmaps-eventual-flamingo.md`)
+delivered Phase 1 (CI bootstrap, doc accuracy, type-bug fixes), Phase 2.1/2.2/2.4
+(dead-code purge, type-safety beachhead), and Phase 3.1/3.2
+(signal notifier scaffold + `backtest_signal` MCP tool with parity
+testing). Phase 2.3 (refactors of `deep_research.py` and
+`llm_optimization.py`) was deliberately deferred for its own
+characterization-test-driven PR series.
+
+This doc captures what's natural to pick up *after* that work, so the
+next plan doesn't start from a blank page.
+
+## Candidate v2 features
+
+### 1. Options analytics
+
+A new `services/options/` domain that ingests an options chain
+(strike, expiry, bid/ask, OI, IV, Greeks where the provider supplies
+them) for a ticker and exposes MCP tools for chain queries, ATM
+straddle pricing, simple Greeks (delta-neutral hedge ratios, dollar
+delta), and IV rank vs trailing window. Reuses the v1 service-layer
+pattern (DB models + service + thin router) and the same
+`EnhancedStockDataProvider` for the underlying. Tiingo's free tier
+does not include options; first-class integration likely requires
+adding `polygon-api-client` or a similar provider behind a feature
+flag.
+
+### 2. Sector rotation
+
+A read-only analytics service over the existing market data that
+ranks sector ETFs (XLK, XLF, XLE, …) by trailing return and relative
+strength vs SPY across 1m/3m/6m windows, surfacing leadership
+rotations as MCP tools and as a `sectors://leadership` resource.
+Stateless, no new domain models — basically a pandas computation on
+top of the existing `get_stock_data` path. Cheap to ship and a
+natural input for the v1 `RegimeDetector` to consume.
+
+### 3. News-driven signal triggers
+
+Wire the existing Exa research path (`agents/optimized_research.py`)
+to the v1 signals event bus: a new `services/signals/news_trigger.py`
+that runs scheduled research queries (using the `MaverickScheduler`)
+for tickers on the watchlist, classifies the result into
+`bullish` / `bearish` / `neutral` using the existing model-selection
+infrastructure, and publishes a `signal.triggered` event with
+`indicator: "news"` when sentiment crosses a threshold. Reuses the
+Phase 3.1 notifier path so news-driven fires reach the same MCP
+resource and webhook surfaces as price-driven ones.
+
+## Carry-forwards from this session
+
+These were called out as deferred in PR #161 / #162 and remain on
+the table:
+
+- **Phase 2.3 refactors** — `deep_research.py` (3,681 LOC) and
+  `llm_optimization.py` (1,675 LOC). Plan: extract two seams from
+  each, not a full rewrite. Add characterization tests against the
+  current public functions before moving code.
+- **Strict-zone burndown completion** — 8 ty diagnostics remain in
+  `services/` + `domain/` after this session. Four are SQLAlchemy
+  `Column[T]` friction that would benefit from a coordinated
+  migration to `Mapped[T]` annotations on the model classes. Once
+  at 0, flip `continue-on-error: true` to `false` in `ci.yml` to
+  gate PRs.
+- **Integration test for end-to-end signal delivery** — publish on
+  the real `EventBus` singleton with Postgres-backed `SignalService`
+  and assert the notifiers receive. Needs Postgres/Redis service
+  containers in CI.
+- **Integration test for `backtest_signal`** — create a real Signal
+  via `SignalService` and run the full tool end-to-end with a
+  vectorbt simulation. Mark `integration` and add to the deferred
+  integration workflow.
+
+## Out of scope (still)
+
+- Re-introducing authentication / multi-user mode — explicitly
+  removed per `CLAUDE.md`.
+- Public hosting / SaaS — this remains a personal-use MCP server.
+- Migrating off `pandas-ta 0.3.14b0` unless a specific bug forces
+  it.
+- Refactoring `data/models.py`, `api/server.py`,
+  `tool_registry.py`, `backtesting/vectorbt_engine.py`, or
+  `providers/stock_data.py` — high-churn, deferred indefinitely.

--- a/maverick_mcp/api/routers/signals.py
+++ b/maverick_mcp/api/routers/signals.py
@@ -428,3 +428,51 @@ def register_signal_tools(mcp: FastMCP) -> None:
         except Exception as e:
             logger.exception("backtest_signal error: %s", e)
             return {"error": str(e)}
+
+    # ------------------------------------------------------------------
+    # MCP resources (Phase 3.1 follow-up)
+    # ------------------------------------------------------------------
+
+    @mcp.resource("signals://recent")
+    def recent_signal_events() -> dict:
+        """Most recent in-memory signal events captured by the resource notifier.
+
+        Reads from the ``MCPResourceNotifier`` registered with the
+        service registry under ``"signal_notifiers"`` during server
+        startup. The buffer is bounded (default 100 events) and is
+        in-process only — restarting the server clears it. Use
+        ``list_signal_events`` for the persistent DB-backed history.
+
+        Returns an empty list with a note when notifiers are disabled
+        (``MAVERICK_SIGNAL_MCP_RESOURCE=0``) or the registry has no
+        ``signal_notifiers`` entry — the resource always succeeds.
+        """
+        try:
+            from maverick_mcp.services import registry as _reg
+
+            notifiers = _reg.get_optional("signal_notifiers")
+            if not notifiers:
+                return {
+                    "events": [],
+                    "count": 0,
+                    "note": (
+                        "Signal notifiers not registered. Set "
+                        "MAVERICK_SIGNAL_MCP_RESOURCE=1 (default) and "
+                        "restart the server."
+                    ),
+                }
+            mcp_resource = notifiers.get("mcp_resource")
+            if mcp_resource is None:
+                return {
+                    "events": [],
+                    "count": 0,
+                    "note": (
+                        "MCP resource notifier not registered. Check "
+                        "MAVERICK_SIGNAL_MCP_RESOURCE environment variable."
+                    ),
+                }
+            events = mcp_resource.recent()
+            return {"events": events, "count": len(events)}
+        except Exception as e:
+            logger.error("recent_signal_events resource error: %s", e)
+            return {"events": [], "count": 0, "error": str(e)}

--- a/maverick_mcp/domain/screening/entities.py
+++ b/maverick_mcp/domain/screening/entities.py
@@ -182,7 +182,7 @@ class ScreeningResult:
         score = 0
 
         # Momentum Score contribution (0-40 points)
-        score += int(self.momentum_score * 0.4)
+        score += int(float(self.momentum_score) * 0.4)
 
         # Volume quality (0-20 points)
         if self.avg_volume_30d >= 1_000_000:
@@ -215,7 +215,7 @@ class ScreeningResult:
             "adr_percentage": float(self.adr_percentage),
             "pattern": self.pattern,
             "squeeze": self.squeeze,
-            "vcp": self.vcp,
+            "consolidation": self.consolidation,
             "entry_signal": self.entry_signal,
             "combined_score": self.combined_score,
             "bear_score": self.bear_score,

--- a/maverick_mcp/domain/screening/services.py
+++ b/maverick_mcp/domain/screening/services.py
@@ -87,7 +87,7 @@ class ScreeningService:
             atr=Decimal(str(raw_data.get("atr", 0))),
             pattern=raw_data.get("pat"),
             squeeze=raw_data.get("sqz"),
-            vcp=raw_data.get("vcp"),
+            consolidation=raw_data.get("vcp") or raw_data.get("consolidation"),
             entry_signal=raw_data.get("entry"),
             combined_score=int(raw_data.get("combined_score", 0)),
             bear_score=int(raw_data.get("score", 0)),  # Bear score uses 'score' field
@@ -201,9 +201,11 @@ class ScreeningService:
                 if r.squeeze is not None and r.squeeze.strip()
             ]
 
-        if criteria.require_vcp:
+        if criteria.require_consolidation:
             filtered_results = [
-                r for r in filtered_results if r.vcp is not None and r.vcp.strip()
+                r
+                for r in filtered_results
+                if r.consolidation is not None and r.consolidation.strip()
             ]
 
         if criteria.require_entry_signal:
@@ -274,13 +276,15 @@ class ScreeningService:
             reverse=sorting.descending,
         )
 
-        # Apply secondary sort if specified
-        if sorting.secondary_field:
+        # Apply secondary sort if specified. Bind to a local so the
+        # type narrowing reaches the lambda below.
+        secondary_field = sorting.secondary_field
+        if secondary_field is not None:
             sorted_results = sorted(
                 sorted_results,
                 key=lambda r: (
                     get_sort_value(r, sorting.field),
-                    get_sort_value(r, sorting.secondary_field),
+                    get_sort_value(r, secondary_field),
                 ),
                 reverse=sorting.descending,
             )

--- a/maverick_mcp/infrastructure/screening/repositories.py
+++ b/maverick_mcp/infrastructure/screening/repositories.py
@@ -107,7 +107,7 @@ class PostgresStockRepository(IStockRepository):
                         "atr": float(stock.atr) if stock.atr else 0.0,
                         "pat": stock.pat,
                         "sqz": stock.sqz,
-                        "vcp": stock.vcp,
+                        "vcp": stock.consolidation_status,
                         "entry": stock.entry,
                         "compression_score": int(stock.compression_score)
                         if stock.compression_score
@@ -205,7 +205,7 @@ class PostgresStockRepository(IStockRepository):
                         else False,
                         "score": int(stock.score) if stock.score else 0,
                         "sqz": stock.sqz,
-                        "vcp": stock.vcp,
+                        "vcp": stock.consolidation_status,
                     }
                     result.append(stock_dict)
                 except (ValueError, TypeError) as e:

--- a/maverick_mcp/services/signals/conditions.py
+++ b/maverick_mcp/services/signals/conditions.py
@@ -155,20 +155,20 @@ def _apply_operator(
     """Return (triggered, new_state) for the given operator."""
 
     if operator == "lt":
-        _require_threshold(threshold, operator)
-        return current_value < threshold, None  # type: ignore[operator]
+        thr = _require_threshold(threshold, operator)
+        return current_value < thr, None
 
     if operator == "gt":
-        _require_threshold(threshold, operator)
-        return current_value > threshold, None  # type: ignore[operator]
+        thr = _require_threshold(threshold, operator)
+        return current_value > thr, None
 
     if operator == "lte":
-        _require_threshold(threshold, operator)
-        return current_value <= threshold, None  # type: ignore[operator]
+        thr = _require_threshold(threshold, operator)
+        return current_value <= thr, None
 
     if operator == "gte":
-        _require_threshold(threshold, operator)
-        return current_value >= threshold, None  # type: ignore[operator]
+        thr = _require_threshold(threshold, operator)
+        return current_value >= thr, None
 
     if operator == "spike":
         return _evaluate_spike(current_value, data, indicator, period, std_devs), None
@@ -184,9 +184,16 @@ def _apply_operator(
     raise ValueError(f"Unknown operator: {operator!r}")
 
 
-def _require_threshold(threshold: float | None, operator: str) -> None:
+def _require_threshold(threshold: float | None, operator: str) -> float:
+    """Validate that *threshold* is set, returning it as a non-optional ``float``.
+
+    Returning the value (instead of raising-only) lets the type checker
+    narrow ``threshold`` to ``float`` at the call site without a cast or
+    assertion.
+    """
     if threshold is None:
         raise ValueError(f"Operator '{operator}' requires a threshold value")
+    return float(threshold)
 
 
 def _evaluate_spike(

--- a/maverick_mcp/services/signals/service.py
+++ b/maverick_mcp/services/signals/service.py
@@ -154,7 +154,7 @@ class SignalService:
 
     async def evaluate_all(
         self,
-        data_fetcher: Callable[[str, int], Awaitable[Any]],
+        data_fetcher: Callable[..., Awaitable[Any]],
     ) -> list[dict[str, Any]]:
         """Evaluate all active signals against fresh market data.
 

--- a/tests/unit/test_signal_notifiers.py
+++ b/tests/unit/test_signal_notifiers.py
@@ -236,3 +236,104 @@ def test_register_default_notifiers_enables_webhook_when_url_set(
     assert set(notifiers) == {"webhook"}
     assert isinstance(notifiers["webhook"], WebhookNotifier)
     assert notifiers["webhook"].url == "https://example.test/w"
+
+
+# ---------------------------------------------------------------------------
+# signals://recent MCP resource (Phase 3.1 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _capture_signals_resource() -> dict:
+    """Register `register_signal_tools` against a fake mcp and return the
+    captured `recent_signal_events` resource handler."""
+
+    captured: dict[str, object] = {}
+
+    class FakeMCP:
+        def tool(self, *_args, **_kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def resource(self, uri):
+            def decorator(fn):
+                captured[uri] = fn
+                return fn
+
+            return decorator
+
+    from maverick_mcp.api.routers.signals import register_signal_tools
+
+    register_signal_tools(FakeMCP())  # type: ignore[arg-type]
+    return captured
+
+
+def test_signals_recent_resource_returns_empty_when_registry_empty() -> None:
+    """If no notifiers are registered, the resource succeeds with a hint."""
+    from maverick_mcp.services import registry
+
+    # Snapshot + clean the relevant slot so we exercise the empty path
+    # without disturbing other tests.
+    saved = registry._services.pop("signal_notifiers", None)
+    try:
+        captured = _capture_signals_resource()
+        recent = captured["signals://recent"]
+        result = recent()  # type: ignore[operator]
+
+        assert result["events"] == []
+        assert result["count"] == 0
+        assert "note" in result
+    finally:
+        if saved is not None:
+            registry._services["signal_notifiers"] = saved
+
+
+@pytest.mark.asyncio
+async def test_signals_recent_resource_reads_buffer_when_registered() -> None:
+    """When the MCPResourceNotifier is registered, the resource returns its buffer."""
+    from maverick_mcp.services import registry
+
+    notifier = MCPResourceNotifier()
+    await notifier.notify(
+        "signal.triggered",
+        {"signal_id": 7, "ticker": "NVDA", "price": 800.0},
+    )
+
+    saved = registry._services.pop("signal_notifiers", None)
+    try:
+        registry.register("signal_notifiers", {"mcp_resource": notifier})
+
+        captured = _capture_signals_resource()
+        recent = captured["signals://recent"]
+        result = recent()  # type: ignore[operator]
+
+        assert result["count"] == 1
+        assert result["events"][0]["topic"] == "signal.triggered"
+        assert result["events"][0]["ticker"] == "NVDA"
+    finally:
+        registry._services.pop("signal_notifiers", None)
+        if saved is not None:
+            registry._services["signal_notifiers"] = saved
+
+
+def test_signals_recent_resource_handles_missing_mcp_resource_key() -> None:
+    """If signal_notifiers is registered but lacks the mcp_resource key, return a hint."""
+    from maverick_mcp.services import registry
+
+    saved = registry._services.pop("signal_notifiers", None)
+    try:
+        # Webhook-only setup.
+        registry.register("signal_notifiers", {"webhook": object()})
+
+        captured = _capture_signals_resource()
+        recent = captured["signals://recent"]
+        result = recent()  # type: ignore[operator]
+
+        assert result["events"] == []
+        assert result["count"] == 0
+        assert "note" in result
+    finally:
+        registry._services.pop("signal_notifiers", None)
+        if saved is not None:
+            registry._services["signal_notifiers"] = saved


### PR DESCRIPTION
## Summary

Three forward-plan items in three logical commits:

| # | Commit | What it does |
|---|--------|---------------|
| 1 | `feat: signals://recent MCP resource handler (Phase 3.1 follow-up)` | Adds the `signals://recent` MCP resource that exposes the Phase 3.1 `MCPResourceNotifier` buffer to MCP clients. Returns `{"events": [...], "count": N}` with a graceful note when notifiers are disabled. 3 new tests via a small `FakeMCP` helper. |
| 2 | `chore: strict-zone ty burndown (21 -> 8 diagnostics)` | Burns down the type-safety beachhead. Real bugs fixed: stale `vcp` references in `domain/screening/{entities,services}.py` and `infrastructure/screening/repositories.py` (the field was renamed to `consolidation_status`/`consolidation` project-wide). Type narrowing nits in `_apply_operator`/`_require_threshold`, `Decimal * float`, secondary-field sort closure, and `data_fetcher` Callable signature. |
| 3 | `docs: v2 roadmap stub (Phase 3.3)` | Short stub doc at `docs/superpowers/plans/2026-Q3-maverick-roadmap-v2.md` so the next planning session starts warm. Three candidate features (options analytics, sector rotation, news-driven triggers), carry-forwards (Phase 2.3, strict-zone completion, integration tests), explicit out-of-scope. |

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pytest -m "not integration and not slow and not external" --maxfail=5 --timeout=60` — 864 passed, 4 skipped, 664 deselected (one unrelated flaky perf test, `test_cache_speedup`, passes in isolation)
- [x] `uv run ty check maverick_mcp/services maverick_mcp/domain` — 8 diagnostics (down from 21)
- [ ] CI workflow runs against this PR; the strict-zone job is informational, the `signals://recent` resource is exercised by the new unit tests
- [ ] Smoke run via `make dev-stdio` in Claude Desktop: `signals://recent` should be listable as a resource and return `{"events": [], "count": 0, "note": "..."}` initially.

## Out of scope (deferred)

- **Phase 2.3** — refactors of `deep_research.py` (3,681 LOC) and `llm_optimization.py` (1,675 LOC) — still parked for a dedicated characterization-test-driven PR series.
- **Strict-zone completion (8 → 0)** — 4 SQLAlchemy `Column[T]` friction issues need a coordinated `Mapped[T]` migration on the model classes; 4 individually tractable nits in `journal/`, `stock_analysis_service.py`, and `technical_analysis_service.py` need targeted investigation. Once at 0, flip `continue-on-error: true` to `false` in `ci.yml`.
- **Integration tests** for end-to-end signal delivery and `backtest_signal` — need Postgres/Redis service containers in CI.