### PR TITLE
Strict-zone burndown to zero + flip the gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,8 @@ jobs:
         continue-on-error: true
         run: uv run ty check maverick_mcp
       # Strict-zone run over the v1 service-layer and domain packages.
-      # Currently 21 diagnostics — kept informational until they're
-      # burned down. Once at 0, flip `continue-on-error` to false to
-      # gate PRs on regressions inside the strict zone.
+      # Now gated: any new diagnostic in this scope fails the job.
       - name: ty check, strict zone (services/ + domain/)
-        continue-on-error: true
         run: uv run ty check maverick_mcp/services maverick_mcp/domain
 
   test-unit:

--- a/maverick_mcp/domain/services/technical_analysis_service.py
+++ b/maverick_mcp/domain/services/technical_analysis_service.py
@@ -54,10 +54,13 @@ class TechnicalAnalysisService:
         avg_gain = gains.rolling(window=period).mean()
         avg_loss = losses.rolling(window=period).mean()
 
-        # Calculate RS and RSI
-        # Handle edge case where there are no losses
-        rs = avg_gain / avg_loss if avg_loss.iloc[-1] != 0 else np.inf
-        rsi = 100 - (100 / (1 + rs))
+        # Calculate RS and RSI. Replacing zeros with NaN keeps `rs`
+        # (and therefore `rsi`) as a Series even when there are no
+        # losses in the window, which avoids a Series-vs-scalar type
+        # split downstream. NaN entries are then mapped to RSI=100
+        # (canonical "no losses ⇒ maximum strength" semantic).
+        rs = avg_gain / avg_loss.replace(0, np.nan)
+        rsi = (100 - (100 / (1 + rs))).fillna(100.0)
 
         # Get the latest RSI value
         current_rsi = float(rsi.iloc[-1])

--- a/maverick_mcp/domain/services/technical_analysis_service.py
+++ b/maverick_mcp/domain/services/technical_analysis_service.py
@@ -46,9 +46,12 @@ class TechnicalAnalysisService:
         # Calculate price changes
         delta = prices.diff()
 
-        # Separate gains and losses
-        gains = delta.where(delta > 0, 0)
-        losses = -delta.where(delta < 0, 0)
+        # Separate gains and losses, but preserve NaN from missing
+        # input data so it propagates through the rolling mean and
+        # downstream RSI value (rather than being silently treated
+        # as a zero-gain or zero-loss bar).
+        gains = delta.where(delta > 0, 0).where(delta.notna())
+        losses = (-delta).where(delta < 0, 0).where(delta.notna())
 
         # Calculate average gains and losses
         avg_gain = gains.rolling(window=period).mean()
@@ -57,10 +60,16 @@ class TechnicalAnalysisService:
         # Calculate RS and RSI. Replacing zeros with NaN keeps `rs`
         # (and therefore `rsi`) as a Series even when there are no
         # losses in the window, which avoids a Series-vs-scalar type
-        # split downstream. NaN entries are then mapped to RSI=100
-        # (canonical "no losses ⇒ maximum strength" semantic).
+        # split downstream. We then map ONLY the zero-divisor case
+        # to RSI=100 (canonical "no losses ⇒ maximum strength"). NaN
+        # arising from missing input data (where avg_gain itself is
+        # NaN, e.g. trailing NaNs in an incomplete fetch) must
+        # propagate so callers can decide how to handle it — coercing
+        # it to 100 would silently fabricate an overbought signal.
         rs = avg_gain / avg_loss.replace(0, np.nan)
-        rsi = (100 - (100 / (1 + rs))).fillna(100.0)
+        rsi = 100 - (100 / (1 + rs))
+        no_loss_with_gain = (avg_loss == 0) & avg_gain.notna()
+        rsi = rsi.mask(no_loss_with_gain, 100.0)
 
         # Get the latest RSI value
         current_rsi = float(rsi.iloc[-1])

--- a/maverick_mcp/domain/stock_analysis/stock_analysis_service.py
+++ b/maverick_mcp/domain/stock_analysis/stock_analysis_service.py
@@ -380,11 +380,17 @@ class StockAnalysisService:
         if isinstance(end_date, str):
             end_date = pd.to_datetime(end_date)
 
-        # Get valid trading days from market calendar
+        # Get valid trading days from market calendar. The schedule
+        # frame is indexed by trading days, so the index is always a
+        # DatetimeIndex at runtime even though pandas' generic type
+        # is `Index`.
         schedule = self.market_calendar.schedule(
             start_date=start_date, end_date=end_date
         )
-        return schedule.index
+        index = schedule.index
+        if not isinstance(index, pd.DatetimeIndex):
+            index = pd.DatetimeIndex(index)
+        return index
 
     def _get_last_trading_day(self, date) -> pd.Timestamp:
         """

--- a/maverick_mcp/domain/value_objects/technical_indicators.py
+++ b/maverick_mcp/domain/value_objects/technical_indicators.py
@@ -5,6 +5,7 @@ These are immutable objects representing technical analysis concepts
 in the domain layer. They contain no infrastructure dependencies.
 """
 
+import math
 from dataclasses import dataclass
 from enum import Enum
 
@@ -37,7 +38,11 @@ class RSIIndicator:
     period: int = 14
 
     def __post_init__(self):
-        if not 0 <= self.value <= 100:
+        # NaN is the canonical "unknown" sentinel — used when the
+        # input window contains missing data (incomplete fetch). The
+        # signals pipeline downstream is NaN-aware (cf. `_safe_float`
+        # in `api/routers/signals.py`).
+        if not math.isnan(self.value) and not 0 <= self.value <= 100:
             raise ValueError("RSI must be between 0 and 100")
         if self.period <= 0:
             raise ValueError("Period must be positive")

--- a/maverick_mcp/services/journal/models.py
+++ b/maverick_mcp/services/journal/models.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
-from sqlalchemy import JSON, Column, DateTime, Float, Integer, String, Text
+from sqlalchemy import JSON, DateTime, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from maverick_mcp.data.models import TimestampMixin
 from maverick_mcp.database.base import Base
@@ -15,24 +17,27 @@ class JournalEntry(Base, TimestampMixin):
 
     __tablename__ = "journal_entries"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    symbol = Column(String(20), nullable=False, index=True)
-    side = Column(String(10), nullable=False)  # "long" | "short"
-    entry_price = Column(Float, nullable=False)
-    exit_price = Column(Float, nullable=True)
-    shares = Column(Float, nullable=False)
-    entry_date = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    side: Mapped[str] = mapped_column(String(10), nullable=False)  # "long" | "short"
+    entry_price: Mapped[float] = mapped_column(nullable=False)
+    exit_price: Mapped[float | None] = mapped_column(nullable=True)
+    shares: Mapped[float] = mapped_column(nullable=False)
+    entry_date: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         nullable=False,
     )
-    exit_date = Column(DateTime(timezone=True), nullable=True)
-    rationale = Column(Text, nullable=True)
-    tags = Column(JSON, default=list)
-    pnl = Column(Float, nullable=True)
-    r_multiple = Column(Float, nullable=True)
-    notes = Column(Text, nullable=True)
-    status = Column(String(10), nullable=False, default="open")  # "open" | "closed"
+    exit_date: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tags: Mapped[list[Any]] = mapped_column(JSON, default=list)
+    pnl: Mapped[float | None] = mapped_column(nullable=True)
+    r_multiple: Mapped[float | None] = mapped_column(nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # "open" | "closed"
+    status: Mapped[str] = mapped_column(String(10), nullable=False, default="open")
 
 
 class StrategyPerformance(Base):
@@ -40,13 +45,15 @@ class StrategyPerformance(Base):
 
     __tablename__ = "strategy_performance"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    strategy_tag = Column(String(100), nullable=False, index=True, unique=True)
-    period = Column(String(20), nullable=False, default="all_time")
-    win_count = Column(Integer, nullable=False, default=0)
-    loss_count = Column(Integer, nullable=False, default=0)
-    total_pnl = Column(Float, nullable=False, default=0.0)
-    avg_win = Column(Float, nullable=False, default=0.0)
-    avg_loss = Column(Float, nullable=False, default=0.0)
-    expectancy = Column(Float, nullable=False, default=0.0)
-    profit_factor = Column(Float, nullable=False, default=0.0)
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    strategy_tag: Mapped[str] = mapped_column(
+        String(100), nullable=False, index=True, unique=True
+    )
+    period: Mapped[str] = mapped_column(String(20), nullable=False, default="all_time")
+    win_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    loss_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    total_pnl: Mapped[float] = mapped_column(nullable=False, default=0.0)
+    avg_win: Mapped[float] = mapped_column(nullable=False, default=0.0)
+    avg_loss: Mapped[float] = mapped_column(nullable=False, default=0.0)
+    expectancy: Mapped[float] = mapped_column(nullable=False, default=0.0)
+    profit_factor: Mapped[float] = mapped_column(nullable=False, default=0.0)

--- a/maverick_mcp/services/screening/models.py
+++ b/maverick_mcp/services/screening/models.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
-from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String
+from sqlalchemy import JSON, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
 
 from maverick_mcp.database.base import Base
 
@@ -14,15 +16,15 @@ class ScreeningRun(Base):
 
     __tablename__ = "screening_runs"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    screen_name = Column(String(255), nullable=False, index=True)
-    run_at = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    screen_name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    run_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         nullable=False,
     )
-    result_count = Column(Integer, nullable=False, default=0)
-    results = Column(JSON, nullable=False, default=list)
+    result_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    results: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list)
 
 
 class ScreeningChange(Base):
@@ -30,14 +32,15 @@ class ScreeningChange(Base):
 
     __tablename__ = "screening_changes"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    run_id = Column(Integer, nullable=False, index=True)
-    symbol = Column(String(20), nullable=False, index=True)
-    change_type = Column(String(20), nullable=False)  # "entry" | "exit" | "rank_change"
-    screen_name = Column(String(255), nullable=False)
-    previous_rank = Column(Integer, nullable=True)
-    new_rank = Column(Integer, nullable=True)
-    detected_at = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    run_id: Mapped[int] = mapped_column(nullable=False, index=True)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    # "entry" | "exit" | "rank_change"
+    change_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    screen_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    previous_rank: Mapped[int | None] = mapped_column(nullable=True)
+    new_rank: Mapped[int | None] = mapped_column(nullable=True)
+    detected_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         nullable=False,
@@ -49,9 +52,13 @@ class ScheduledJob(Base):
 
     __tablename__ = "scheduled_jobs"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    job_name = Column(String(255), nullable=False, unique=True)
-    job_type = Column(String(100), nullable=False)
-    schedule_config = Column(JSON, nullable=False, default=dict)
-    active = Column(Boolean, nullable=False, default=True)
-    last_run_at = Column(DateTime(timezone=True), nullable=True)
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    job_name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    job_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    schedule_config: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
+    active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/maverick_mcp/services/signals/models.py
+++ b/maverick_mcp/services/signals/models.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
-from sqlalchemy import JSON, Boolean, Column, DateTime, Float, Integer, String
+from sqlalchemy import JSON, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
 
 from maverick_mcp.data.models import TimestampMixin
 from maverick_mcp.database.base import Base
@@ -15,13 +17,13 @@ class Signal(Base, TimestampMixin):
 
     __tablename__ = "signals"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    label = Column(String(255), nullable=False)
-    ticker = Column(String(10), nullable=False, index=True)
-    condition = Column(JSON, nullable=False)
-    interval_seconds = Column(Integer, default=300)
-    active = Column(Boolean, default=True, nullable=False)
-    previous_state = Column(JSON, nullable=True)
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    label: Mapped[str] = mapped_column(String(255), nullable=False)
+    ticker: Mapped[str] = mapped_column(String(10), nullable=False, index=True)
+    condition: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    interval_seconds: Mapped[int] = mapped_column(default=300)
+    active: Mapped[bool] = mapped_column(default=True, nullable=False)
+    previous_state: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
 
 class SignalEvent(Base, TimestampMixin):
@@ -29,15 +31,17 @@ class SignalEvent(Base, TimestampMixin):
 
     __tablename__ = "signal_events"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    signal_id = Column(Integer, nullable=False, index=True)
-    triggered_at = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    signal_id: Mapped[int] = mapped_column(nullable=False, index=True)
+    triggered_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         nullable=False,
     )
-    price_at_trigger = Column(Float, nullable=True)
-    condition_snapshot = Column(JSON, nullable=True)
+    price_at_trigger: Mapped[float | None] = mapped_column(nullable=True)
+    condition_snapshot: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
+    )
 
 
 class RegimeEvent(Base, TimestampMixin):
@@ -45,12 +49,12 @@ class RegimeEvent(Base, TimestampMixin):
 
     __tablename__ = "regime_events"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    regime = Column(String(20), nullable=False)
-    confidence = Column(Float, nullable=False)
-    drivers = Column(JSON, nullable=True)
-    previous_regime = Column(String(20), nullable=True)
-    detected_at = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    regime: Mapped[str] = mapped_column(String(20), nullable=False)
+    confidence: Mapped[float] = mapped_column(nullable=False)
+    drivers: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    previous_regime: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    detected_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         nullable=False,

--- a/maverick_mcp/services/signals/models.py
+++ b/maverick_mcp/services/signals/models.py
@@ -21,7 +21,9 @@ class Signal(Base, TimestampMixin):
     label: Mapped[str] = mapped_column(String(255), nullable=False)
     ticker: Mapped[str] = mapped_column(String(10), nullable=False, index=True)
     condition: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
-    interval_seconds: Mapped[int] = mapped_column(default=300)
+    # Nullable preserved from pre-Mapped Column(Integer, default=300); rows
+    # always get a default at insert time but the column is nominally nullable.
+    interval_seconds: Mapped[int | None] = mapped_column(default=300)
     active: Mapped[bool] = mapped_column(default=True, nullable=False)
     previous_state: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 

--- a/tests/domain/test_technical_analysis_service.py
+++ b/tests/domain/test_technical_analysis_service.py
@@ -5,6 +5,8 @@ These tests demonstrate that the domain service can be tested
 without any infrastructure dependencies (no mocks needed).
 """
 
+import math
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -73,6 +75,31 @@ class TestTechnicalAnalysisService:
 
         with pytest.raises(ValueError, match="Need at least 14 prices"):
             service.calculate_rsi(prices, period=14)
+
+    def test_calculate_rsi_no_losses_returns_100(self, service):
+        """Strictly monotonic gains ⇒ avg_loss=0 ⇒ RSI=100 (max strength)."""
+        prices = pd.Series([100.0 + i for i in range(20)])  # +1 every bar
+
+        rsi = service.calculate_rsi(prices, period=14)
+
+        assert rsi.value == 100.0
+
+    def test_calculate_rsi_propagates_missing_data(self, service):
+        """NaN from incomplete fetches must NOT be coerced to 100.
+
+        Regression for PR #163 review: an earlier `fillna(100.0)` call
+        replaced *every* NaN, including ones arising from missing
+        input data, silently fabricating a max-strength signal where
+        the real answer is "we don't know".
+        """
+        # Fifteen valid prices followed by a NaN at the tail.
+        prices = pd.Series([100.0 + i for i in range(15)] + [float("nan")])
+
+        rsi = service.calculate_rsi(prices, period=14)
+
+        assert math.isnan(rsi.value), (
+            f"Trailing NaN in input must propagate to RSI; got {rsi.value}"
+        )
 
     def test_calculate_macd(self, service, sample_prices):
         """Test MACD calculation."""


### PR DESCRIPTION
## Summary

Closes the strict-zone type-safety beachhead loop opened in PR #160 (Phase 2.4) and continued in PR #162. Three commits, ending with the gate flipped.

| # | Commit | What it does |
|---|--------|---------------|
| 1 | `refactor: migrate v1 service-layer models to SQLAlchemy 2.0 Mapped[T]` | Migrates Signal/SignalEvent/RegimeEvent, ScreeningRun/ScreeningChange/ScheduledJob, and JournalEntry/StrategyPerformance to `Mapped[T]` annotations. Carries the typing through to call sites — clears 4 SQLAlchemy `Column[T]` friction errors plus all the secondary effects in `journal/`. |
| 2 | `fix: type-narrow the last two strict-zone diagnostics` | (a) RSI calc used a conditional that produced `Series \| float`; rewritten to stay Series-valued throughout, preserving the "no losses ⇒ RSI=100" semantic. (b) `_get_trading_days` declared return `pd.DatetimeIndex` but `schedule.index` is typed `pd.Index`; narrows with `isinstance` and reconstructs on the unreachable branch. |
| 3 | `ci: gate strict-zone ty checks (services/ + domain/) on PRs` | Drops `continue-on-error: true` from the strict-zone step so any new diagnostic in `maverick_mcp/services/` or `maverick_mcp/domain/` fails the PR. |

## Burndown progression

| Phase | services/ + domain/ ty diagnostics |
|-------|------------------------------------|
| Pre-Phase 2.4 baseline | 23 |
| After PR #160 (Phase 2.4 utcnow fix) | 21 |
| After PR #162 (vcp rename + narrowings) | 8 |
| After this PR | **0** |

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pytest -m "not integration and not slow and not external" --maxfail=5 --timeout=60` — 864 passed, 4 skipped, 664 deselected
- [x] `uv run ty check maverick_mcp/services maverick_mcp/domain` — **0 diagnostics**
- [ ] CI workflow runs against this PR; the strict-zone step is now gating
- [ ] Smoke run via `make dev-stdio`: existing tools (`create_signal`, `list_signals`, `evaluate_all`, `add_trade`, `screening_pipeline`, `backtest_signal`) still work end-to-end. The Mapped migration changes only column declaration syntax, not SQL semantics, but it's worth a sanity check.

## Out of scope (still deferred)

- **Phase 2.3** — refactors of `deep_research.py` (3,681 LOC) and `llm_optimization.py` (1,675 LOC). Still parked for a dedicated characterization-test-driven PR series.
- **Full-package strict typing** — `ty check maverick_mcp` still emits ~790 diagnostics from the LangChain/LangGraph integration surface. Kept as informational. Consider expanding the strict zone gradually once new packages are added.
- **Integration tests** for end-to-end signal delivery and `backtest_signal` — need Postgres/Redis service containers in CI.