### PR TITLE
[codex] Skip Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,21 +6,52 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    # Forked pull_request runs do not receive repository secrets/OIDC, so keep
+    # the action off for forks and skip it below if the token is not configured.
+    if: >
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: read
       id-token: write
+    env:
+      HAS_CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
 
     steps:
+      - name: Skip Claude Code Review
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN != 'true'
+        run: echo "Skipping Claude Code Review because CLAUDE_CODE_OAUTH_TOKEN is not configured."
+
       - name: Checkout repository
-        uses: actions/checkout@v6
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect Claude review workflow changes
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
+        id: claude-workflow
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if git diff --name-only "origin/${BASE_REF}"...HEAD | grep -Fxq ".github/workflows/claude-code-review.yml"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip Claude Code Review for workflow changes
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true' && steps.claude-workflow.outputs.changed == 'true'
+        run: echo "Skipping Claude Code Review because this PR changes the Claude review workflow."
 
       - name: Run Claude Code Review
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true' && steps.claude-workflow.outputs.changed != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## 📋 Pull Request Summary

**Brief description of changes:**
Hardens the Claude Code Review workflow so it does not fail before review starts when GitHub withholds secrets/OIDC for fork PRs, Dependabot PRs, draft PRs, or PRs that modify the Claude review workflow itself.

**Related issue(s):**
- Follow-up from the Claude Code Review action failure observed on PR #179.

## 💰 Financial Disclaimer Acknowledgment

- [x] I understand this is educational software and not financial advice
- [x] Any financial analysis features include appropriate disclaimers
- [x] This PR maintains the educational/personal-use focus of the project

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Chore (maintenance, dependencies, CI, etc.)

## 🎯 Component Areas

- [x] Claude Desktop integration
- [x] Development tools and setup

## 🔧 Implementation Details

**Key changes made:**
- Skips Claude Code Review for forked PRs, draft PRs, and Dependabot PRs where repository secrets/OIDC are unavailable or intentionally withheld.
- Keeps a visible skip path when CLAUDE_CODE_OAUTH_TOKEN is not configured.
- Skips the Claude review action when a PR modifies the Claude review workflow file, avoiding the action validation failure for self-updating workflows.
- Pins the checkout action to the verified v6.0.0 commit SHA, disables persisted checkout credentials, and passes github.base_ref through an environment variable before using it in Bash.

## 🧪 Testing

- [x] Manual testing completed

**Manual testing performed:**
- Ruby YAML parser successfully loaded .github/workflows/claude-code-review.yml.
- git diff --check completed without whitespace errors.
- GitHub checks for this PR are expected to cover linting, type checking, unit tests, CodeRabbit, and the Claude review workflow path after this update.

## 📊 Financial Analysis Impact

- [x] No financial calculations affected
- [x] No data provider changes
- [x] No investment recommendations modified

**Explanation:**
This PR only changes GitHub Actions workflow behavior.

## 🔒 Security Considerations

- [x] No hardcoded secrets or credentials
- [x] API keys handled securely via environment variables
- [x] No new external API calls

**Security notes:**
- Fork PRs remain unable to access repository secrets.
- The checkout token is no longer persisted into the local Git configuration.
- The workflow action reference for checkout is pinned to an immutable commit SHA.

## ✅ Pre-submission Checklist

- [x] I have performed a self-review of my code
- [x] I have tested the changes locally
- [x] My changes generate no new warnings
- [x] No new linting errors introduced
- [x] Type checking remains covered by CI
- [x] Unit tests remain covered by CI
- [x] No new dependencies added
- [x] Changes are minimal and focused
