### PR TITLE
Integrate VectorBT and Kaleido dependency updates

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   claude-review:
     # Forked pull_request runs do not receive repository secrets/OIDC, so keep
-    # the action off for forks and skip it below if the credential is not configured.
+    # the action off for forks and skip it below if the token is not configured.
     if: >
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
@@ -19,22 +19,22 @@ jobs:
       issues: read
       id-token: write
     env:
-      HAS_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+      HAS_CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
 
     steps:
       - name: Skip Claude Code Review
-        if: env.HAS_ANTHROPIC_API_KEY != 'true'
-        run: echo "Skipping Claude Code Review because ANTHROPIC_API_KEY is not configured."
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN != 'true'
+        run: echo "Skipping Claude Code Review because CLAUDE_CODE_OAUTH_TOKEN is not configured."
 
       - name: Checkout repository
-        if: env.HAS_ANTHROPIC_API_KEY == 'true'
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Detect Claude review workflow changes
-        if: env.HAS_ANTHROPIC_API_KEY == 'true'
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
         id: claude-workflow
         shell: bash
         env:
@@ -47,15 +47,15 @@ jobs:
           fi
 
       - name: Skip Claude Code Review for workflow changes
-        if: env.HAS_ANTHROPIC_API_KEY == 'true' && steps.claude-workflow.outputs.changed == 'true'
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true' && steps.claude-workflow.outputs.changed == 'true'
         run: echo "Skipping Claude Code Review because this PR changes the Claude review workflow."
 
       - name: Run Claude Code Review
-        if: env.HAS_ANTHROPIC_API_KEY == 'true' && steps.claude-workflow.outputs.changed != 'true'
+        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true' && steps.claude-workflow.outputs.changed != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
 
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   claude-review:
     # Forked pull_request runs do not receive repository secrets/OIDC, so keep
-    # the action off for forks and skip it below if the token is not configured.
+    # the action off for forks and skip it below if the credential is not configured.
     if: >
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
@@ -19,22 +19,22 @@ jobs:
       issues: read
       id-token: write
     env:
-      HAS_CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+      HAS_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
 
     steps:
       - name: Skip Claude Code Review
-        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN != 'true'
-        run: echo "Skipping Claude Code Review because CLAUDE_CODE_OAUTH_TOKEN is not configured."
+        if: env.HAS_ANTHROPIC_API_KEY != 'true'
+        run: echo "Skipping Claude Code Review because ANTHROPIC_API_KEY is not configured."
 
       - name: Checkout repository
-        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
+        if: env.HAS_ANTHROPIC_API_KEY == 'true'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Detect Claude review workflow changes
-        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
+        if: env.HAS_ANTHROPIC_API_KEY == 'true'
         id: claude-workflow
         shell: bash
         env:
@@ -47,15 +47,15 @@ jobs:
           fi
 
       - name: Skip Claude Code Review for workflow changes
-        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true' && steps.claude-workflow.outputs.changed == 'true'
+        if: env.HAS_ANTHROPIC_API_KEY == 'true' && steps.claude-workflow.outputs.changed == 'true'
         run: echo "Skipping Claude Code Review because this PR changes the Claude review workflow."
 
       - name: Run Claude Code Review
-        if: env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true' && steps.claude-workflow.outputs.changed != 'true'
+        if: env.HAS_ANTHROPIC_API_KEY == 'true' && steps.claude-workflow.outputs.changed != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
 
           prompt: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install system dependencies and TA-Lib
-RUN apt-get update && apt-get install -yqq \
+# Install system dependencies, Chromium for Kaleido v1 image export, and TA-Lib
+RUN apt-get update && apt-get install -yqq --no-install-recommends \
   build-essential \
-  python3-dev \
-  libpq-dev \
-  wget \
+  ca-certificates \
+  chromium \
   curl \
+  fonts-liberation \
+  libpq-dev \
+  python3-dev \
+  wget \
   && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast Python package management
@@ -42,6 +45,7 @@ COPY alembic.ini setup.py ./
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
+ENV BROWSER_PATH=/usr/bin/chromium
 
 # Create non-root user
 RUN groupadd -g 1000 maverick && \

--- a/maverick_mcp/config/plotly_config.py
+++ b/maverick_mcp/config/plotly_config.py
@@ -40,8 +40,8 @@ def configure_plotly_defaults() -> None:
         # Configure additional defaults that don't trigger deprecation warnings
         if hasattr(pio.defaults, "mathjax"):
             pio.defaults.mathjax = None
-        if hasattr(pio.defaults, "plotlyjs"):
-            pio.defaults.plotlyjs = "auto"
+        # Leave pio.defaults.plotlyjs unset. Kaleido 1.3 treats the string "auto"
+        # as a filesystem path and fails image export with "auto does not exist".
 
         # Note: We avoid setting kaleido.scope properties directly to prevent warnings
         # The modern pio.defaults API should be used instead

--- a/maverick_mcp/domain/stock_analysis/stock_analysis_service.py
+++ b/maverick_mcp/domain/stock_analysis/stock_analysis_service.py
@@ -233,15 +233,17 @@ class StockAnalysisService:
                     f"No trading days found between {start_date} and {end_date}"
                 )
                 return pd.DataFrame(
-                    columns=[
-                        "Open",
-                        "High",
-                        "Low",
-                        "Close",
-                        "Volume",
-                        "Dividends",
-                        "Stock Splits",
-                    ]
+                    columns=pd.Index(
+                        [
+                            "Open",
+                            "High",
+                            "Low",
+                            "Close",
+                            "Volume",
+                            "Dividends",
+                            "Stock Splits",
+                        ]
+                    )
                 )
 
             # Fetch data only for the trading day range

--- a/maverick_mcp/providers/stock_data.py
+++ b/maverick_mcp/providers/stock_data.py
@@ -216,15 +216,17 @@ class EnhancedStockDataProvider:
                         f"No trading days found between {start_date} and {end_date}"
                     )
                     return pd.DataFrame(
-                        columns=[  # type: ignore[arg-type]
-                            "Open",
-                            "High",
-                            "Low",
-                            "Close",
-                            "Volume",
-                            "Dividends",
-                            "Stock Splits",
-                        ]
+                        columns=pd.Index(
+                            [
+                                "Open",
+                                "High",
+                                "Low",
+                                "Close",
+                                "Volume",
+                                "Dividends",
+                                "Stock Splits",
+                            ]
+                        )
                     )
 
                 # Fetch data only for the trading day range
@@ -359,7 +361,7 @@ class EnhancedStockDataProvider:
             start_date=start_date, end_date=end_date
         )
         # Return timezone-naive index
-        return schedule.index.tz_localize(None)
+        return pd.DatetimeIndex(schedule.index).tz_localize(None)
 
     def _get_last_trading_day(self, date) -> pd.Timestamp:
         """
@@ -672,7 +674,7 @@ class EnhancedStockDataProvider:
         if df.empty:
             logger.warning(f"Empty dataframe returned for {symbol}")
             return pd.DataFrame(
-                columns=["Open", "High", "Low", "Close", "Volume"]  # type: ignore[arg-type]
+                columns=pd.Index(["Open", "High", "Low", "Close", "Volume"])
             )
 
         # Ensure all expected columns exist
@@ -1214,13 +1216,15 @@ class EnhancedStockDataProvider:
 
             if not news:
                 return pd.DataFrame(
-                    columns=[  # type: ignore[arg-type]
-                        "title",
-                        "publisher",
-                        "link",
-                        "providerPublishTime",
-                        "type",
-                    ]
+                    columns=pd.Index(
+                        [
+                            "title",
+                            "publisher",
+                            "link",
+                            "providerPublishTime",
+                            "type",
+                        ]
+                    )
                 )
 
             df = pd.DataFrame(news[:limit])
@@ -1235,7 +1239,9 @@ class EnhancedStockDataProvider:
         except Exception as e:
             logger.error(f"Error fetching news for {symbol}: {str(e)}")
             return pd.DataFrame(
-                columns=["title", "publisher", "link", "providerPublishTime", "type"]  # type: ignore[arg-type]
+                columns=pd.Index(
+                    ["title", "publisher", "link", "providerPublishTime", "type"]
+                )
             )
 
     def get_earnings(self, symbol: str) -> dict:
@@ -1264,12 +1270,16 @@ class EnhancedStockDataProvider:
             recommendations = ticker.recommendations
 
             if recommendations is None or recommendations.empty:
-                return pd.DataFrame(columns=["firm", "toGrade", "fromGrade", "action"])  # type: ignore[arg-type]
+                return pd.DataFrame(
+                    columns=pd.Index(["firm", "toGrade", "fromGrade", "action"])
+                )
 
             return recommendations
         except Exception as e:
             logger.error(f"Error fetching recommendations for {symbol}: {str(e)}")
-            return pd.DataFrame(columns=["firm", "toGrade", "fromGrade", "action"])  # type: ignore[arg-type]
+            return pd.DataFrame(
+                columns=pd.Index(["firm", "toGrade", "fromGrade", "action"])
+            )
 
     def is_etf(self, symbol: str) -> bool:
         """Check if a given symbol is an ETF."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=4.1.0",
+    "pytest-timeout>=2.4.0",
     "pytest-xdist>=3.6.0",
     "testcontainers[postgres,redis]>=4.5.0",
     "vcrpy>=6.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "pandas-ta>=0.3.14b0",
     "ta-lib>=0.6.3",
     # Backtesting
-    "vectorbt>=0.26.0",
+    "vectorbt>=1.0.0",
     "numba>=0.60.0",
     "scikit-learn>=1.6.1",
     "scipy>=1.15.3",
@@ -70,7 +70,7 @@ dependencies = [
     "matplotlib>=3.10.3",
     "plotly>=6.7.0",
     "seaborn>=0.13.2",
-    "kaleido>=0.2.1", # Required for Plotly image export
+    "kaleido>=1.3.0", # Required for Plotly image export
     # Development tools
     "watchdog>=6.0.0",
     "ty>=0.0.1a19",

--- a/tests/test_plotly_config.py
+++ b/tests/test_plotly_config.py
@@ -1,9 +1,11 @@
 import plotly.io as pio
+import pytest
 
 from maverick_mcp.config.plotly_config import configure_plotly_defaults
 
 
-def test_configure_plotly_defaults_leaves_plotlyjs_unset():
+@pytest.mark.unit
+def test_configure_plotly_defaults_leaves_plotlyjs_unset() -> None:
     """Kaleido 1.3 expects plotlyjs to be None, not the string 'auto'."""
     if hasattr(pio.defaults, "plotlyjs"):
         pio.defaults.plotlyjs = None

--- a/tests/test_plotly_config.py
+++ b/tests/test_plotly_config.py
@@ -1,0 +1,13 @@
+import plotly.io as pio
+
+from maverick_mcp.config.plotly_config import configure_plotly_defaults
+
+
+def test_configure_plotly_defaults_leaves_plotlyjs_unset():
+    """Kaleido 1.3 expects plotlyjs to be None, not the string 'auto'."""
+    if hasattr(pio.defaults, "plotlyjs"):
+        pio.defaults.plotlyjs = None
+
+    configure_plotly_defaults()
+
+    assert getattr(pio.defaults, "plotlyjs", None) is None

--- a/uv.lock
+++ b/uv.lock
@@ -158,6 +158,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anywidget"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipywidgets" },
+    { name = "psygnal" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/31/0491d707c674b34267f55d96d6a7148e55e7b6718a271686232cf295fbe2/anywidget-0.11.0.tar.gz", hash = "sha256:6695fbef9449cf8c27f421b96c5837aa37f909ec1f60cfa33add333e1b70b169", size = 426999, upload-time = "2026-04-27T23:42:09.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/c2/8fec8e8e2eb920cc2280f569144080cd58622a2eda83bfa4c0c354a63264/anywidget-0.11.0-py3-none-any.whl", hash = "sha256:c574d9acc6503ad27b37a9acea48f957a8ba7c9c9876cfcb37898931c098ce9d", size = 317341, upload-time = "2026-04-27T23:42:08.356Z" },
+]
+
+[[package]]
 name = "apscheduler"
 version = "3.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -394,15 +408,16 @@ wheels = [
 
 [[package]]
 name = "choreographer"
-version = "1.2.1"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "logistro" },
+    { name = "platformdirs" },
     { name = "simplejson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/47/64a035c6f764450ea9f902cbeba14c8c70316c2641125510066d8f912bfa/choreographer-1.2.1.tar.gz", hash = "sha256:022afd72b1e9b0bcb950420b134e70055a294c791b6f36cfb47d89745b701b5f", size = 43399, upload-time = "2025-11-09T23:04:44.749Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/69/3058cd4f16d6b75c80e8f95e5b713d930526353ce294df9a7887453ba215/choreographer-1.3.0.tar.gz", hash = "sha256:6c44a0e48e9b37977344d40bfa5a9ed88575fe4bc0fd836771bf702bc24d6884", size = 48291, upload-time = "2026-04-28T22:57:45.114Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/9f/d73dfb85d7a5b1a56a99adc50f2074029468168c970ff5daeade4ad819e4/choreographer-1.2.1-py3-none-any.whl", hash = "sha256:9af5385effa3c204dbc337abf7ac74fd8908ced326a15645dc31dde75718c77e", size = 49338, upload-time = "2025-11-09T23:04:43.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/6c/ff8bf52315064dbeb55cb5067e191120a5b2e58bb648d0d34cf7969dc2c2/choreographer-1.3.0-py3-none-any.whl", hash = "sha256:cea4cb739e4f61625e4b53888a8d3fa1d3bf73948b56753e460ab44da7d8d44f", size = 52622, upload-time = "2026-04-28T22:57:44.015Z" },
 ]
 
 [[package]]
@@ -1422,18 +1437,17 @@ wheels = [
 
 [[package]]
 name = "kaleido"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "choreographer" },
     { name = "logistro" },
     { name = "orjson" },
     { name = "packaging" },
-    { name = "pytest-timeout" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/ad/76eec859b71eda803a88ea50ed3f270281254656bb23d19eb0a39aa706a0/kaleido-1.2.0.tar.gz", hash = "sha256:fa621a14423e8effa2895a2526be00af0cf21655be1b74b7e382c171d12e71ef", size = 64160, upload-time = "2025-11-04T21:24:23.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/64/53eac73d31dbfc3310ee2e87bcac1ae7417427f0fbe3dd800eaf676db324/kaleido-1.3.0.tar.gz", hash = "sha256:5e0378a7475e98852773deeb6483dee91f8aa7b364dde7b5f2b3622cb468a3e6", size = 68938, upload-time = "2026-05-04T19:45:28.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/97/f6de8d4af54d6401d6581a686cce3e3e2371a79ba459a449104e026c08bc/kaleido-1.2.0-py3-none-any.whl", hash = "sha256:c27ed82b51df6b923d0e656feac221343a0dbcd2fb9bc7e6b1db97f61e9a1513", size = 68997, upload-time = "2025-11-04T21:24:21.704Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/a6d8bb7d228940f01885bd9f327ab7f9d366a9be775c4bf366bf9d9477ae/kaleido-1.3.0-py3-none-any.whl", hash = "sha256:52714dfd38e8f2a114831826200c40bb10d0ca0c11d4272f3f48ad499cd8f8ea", size = 55580, upload-time = "2026-05-04T19:45:27.483Z" },
 ]
 
 [[package]]
@@ -2009,7 +2023,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "hiredis", specifier = ">=3.2.1" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "kaleido", specifier = ">=0.2.1" },
+    { name = "kaleido", specifier = ">=1.3.0" },
     { name = "langchain", specifier = ">=0.3.25" },
     { name = "langchain-anthropic", specifier = ">=0.3.15" },
     { name = "langchain-community", specifier = ">=0.3.24" },
@@ -2062,7 +2076,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "vcrpy", specifier = ">=7.0.0" },
     { name = "vcrpy", marker = "extra == 'dev'", specifier = ">=6.0.1" },
-    { name = "vectorbt", specifier = ">=0.26.0" },
+    { name = "vectorbt", specifier = ">=1.0.0" },
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "yfinance", specifier = ">=1.3.0" },
 ]
@@ -2459,23 +2473,23 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "3.0.1"
+version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/51/b467209c08dae2c624873d7491ea47d2b47336e5403309d433ea79c38571/pandas-3.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:476f84f8c20c9f5bc47252b66b4bb25e1a9fc2fa98cead96744d8116cb85771d", size = 10344357, upload-time = "2026-02-17T22:18:38.262Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f1/e2567ffc8951ab371db2e40b2fe068e36b81d8cf3260f06ae508700e5504/pandas-3.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ab749dfba921edf641d4036c4c21c0b3ea70fea478165cb98a998fb2a261955", size = 9884543, upload-time = "2026-02-17T22:18:41.476Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/39/327802e0b6d693182403c144edacbc27eb82907b57062f23ef5a4c4a5ea7/pandas-3.0.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8e36891080b87823aff3640c78649b91b8ff6eea3c0d70aeabd72ea43ab069b", size = 10396030, upload-time = "2026-02-17T22:18:43.822Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/fe/89d77e424365280b79d99b3e1e7d606f5165af2f2ecfaf0c6d24c799d607/pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:532527a701281b9dd371e2f582ed9094f4c12dd9ffb82c0c54ee28d8ac9520c4", size = 10876435, upload-time = "2026-02-17T22:18:45.954Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/a6/2a75320849dd154a793f69c951db759aedb8d1dd3939eeacda9bdcfa1629/pandas-3.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:356e5c055ed9b0da1580d465657bc7d00635af4fd47f30afb23025352ba764d1", size = 11405133, upload-time = "2026-02-17T22:18:48.533Z" },
-    { url = "https://files.pythonhosted.org/packages/58/53/1d68fafb2e02d7881df66aa53be4cd748d25cbe311f3b3c85c93ea5d30ca/pandas-3.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9d810036895f9ad6345b8f2a338dd6998a74e8483847403582cab67745bff821", size = 11932065, upload-time = "2026-02-17T22:18:50.837Z" },
-    { url = "https://files.pythonhosted.org/packages/75/08/67cc404b3a966b6df27b38370ddd96b3b023030b572283d035181854aac5/pandas-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:536232a5fe26dd989bd633e7a0c450705fdc86a207fec7254a55e9a22950fe43", size = 9741627, upload-time = "2026-02-17T22:18:53.905Z" },
-    { url = "https://files.pythonhosted.org/packages/86/4f/caf9952948fb00d23795f09b893d11f1cacb384e666854d87249530f7cbe/pandas-3.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f463ebfd8de7f326d38037c7363c6dacb857c5881ab8961fb387804d6daf2f7", size = 9052483, upload-time = "2026-02-17T22:18:57.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
 ]
 
 [[package]]
@@ -2702,6 +2716,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/66/ea/d3390e6696276078bd01b2ece417deac954dfdd552d2edc3d03204416c0c/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:edcb3aeb11cb4bf13a2af3c53a15b3d612edeb6409047ea0b5d6a21a9d744b34", size = 3044641, upload-time = "2025-10-30T02:55:19.929Z" },
     { url = "https://files.pythonhosted.org/packages/12/9a/0402ded6cbd321da0c0ba7d34dc12b29b14f5764c2fc10750daa38e825fc/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b6d93d7c0b61a1dd6197d208ab613eb7dcfdcca0a49c42ceb082257991de9d", size = 3347940, upload-time = "2025-10-10T11:12:26.529Z" },
     { url = "https://files.pythonhosted.org/packages/b1/d2/99b55e85832ccde77b211738ff3925a5d73ad183c0b37bcbbe5a8ff04978/psycopg2_binary-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:b33fabeb1fde21180479b2d4667e994de7bbf0eec22832ba5d9b5e4cf65b6c6d", size = 2714147, upload-time = "2025-10-10T11:12:29.535Z" },
+]
+
+[[package]]
+name = "psygnal"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/79/20c3e23e75272e9ddf018097cf872ab088bccba978888472656629efa4a3/psygnal-0.15.1.tar.gz", hash = "sha256:f64f62dee2306fc1c22050a59b6c6cdad126e04b0cf50e393ff858a1da719096", size = 123147, upload-time = "2026-01-04T16:38:41.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/65/b7bbca96bc477aa9ac2264e5907b2f4ccfcd1319f776dd1f35eec06cc2f4/psygnal-0.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d56f0f35eaf4a21f660de76885222faf9e8c7112454528d3394d464f3d4d1a3", size = 598340, upload-time = "2026-01-04T16:38:19.752Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/56577465a1b42a5e6780bb5fab53fb68f8bfd72f0131ed397576529af724/psygnal-0.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0febcf757a1323d9b8bd75735ee3569213d8110012a7bf0f478e85c5ab459fc6", size = 575311, upload-time = "2026-01-04T16:38:21.137Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/f642ac08104049383076f83480ed412c9626e068769a1c34873c595bec0e/psygnal-0.15.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b5e4837dfbfa4974dabe0795e32be9aadcd87603adf734738ce1114f72238a05", size = 889770, upload-time = "2026-01-04T16:38:22.629Z" },
+    { url = "https://files.pythonhosted.org/packages/de/43/e571fa40b72780abed080ef829e5ad98017b6fe48d28c15a2404e006b676/psygnal-0.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07b4c4e03bbf4e8cad7e25f4fbc1ba9575fb9c3d14991bc7edfeb8b09c8d6d54", size = 881105, upload-time = "2026-01-04T16:38:23.896Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/ef3ab825eb08eaecbbceeeb56383694fe64ce399dbfd1d0767bb85688785/psygnal-0.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:4f0ce91b9c18e92281bf2c3fc4bb4e808d90f0b023d0a37b302d354188520338", size = 418969, upload-time = "2026-01-04T16:38:25.731Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/7742544684bee728ec123515d2694cee859aa2a705951a461230b00f18cc/psygnal-0.15.1-py3-none-any.whl", hash = "sha256:4221140e633e45b076953c64bcb9b41a744833527f9a037c1ca98bc270798cbf", size = 90638, upload-time = "2026-01-04T16:38:40.841Z" },
 ]
 
 [[package]]
@@ -2973,18 +3001,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "pytest-timeout"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]
@@ -3901,9 +3917,10 @@ wheels = [
 
 [[package]]
 name = "vectorbt"
-version = "0.28.2"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anywidget" },
     { name = "dateparser" },
     { name = "dill" },
     { name = "imageio" },
@@ -3921,9 +3938,9 @@ dependencies = [
     { name = "scipy" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/a7/15e6af76aa8dafd18c7fae2068de889a385fd13eb804aacb8e0310765f1b/vectorbt-0.28.2.tar.gz", hash = "sha256:e1a5b7a11c0e2b5b271f18093cb7d1ea075d94d711388c0f423355e83c63c104", size = 487377, upload-time = "2025-12-12T16:18:12.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/55/257d9217301d0817b4b0b2ed74e8949d1084d6457ad032c13ab81e652c3a/vectorbt-1.0.0.tar.gz", hash = "sha256:e42cd61ecdabb165bf7a482516f15f48b0173ad17629c875916dacfdc39b8fb0", size = 546226, upload-time = "2026-04-22T13:30:02.032Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/b9/250f7a1d033618bd0e43ae40bc180aa88895c907876ca39e219a45caecca/vectorbt-0.28.2-py3-none-any.whl", hash = "sha256:93e5fb20d2ff072b7fed78603b516eb64f967c9bf9420ce8ba28329af0410e7d", size = 527808, upload-time = "2025-12-12T16:18:10.624Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/08/c15c7ade057b0633ac39fe6f5fffa37c306304745538c4f9187a05e9aa69/vectorbt-1.0.0-py3-none-any.whl", hash = "sha256:c596e11bdad985181150f3b3c8db0a7322c738fbb64c7a919a0418e99326cc13", size = 451657, upload-time = "2026-04-22T13:29:59.982Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1986,6 +1986,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "safety" },
@@ -2053,6 +2054,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.27" },
@@ -3001,6 +3003,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Integrate the Dependabot dependency updates for VectorBT and Kaleido onto one replacement branch.
- Raise VectorBT to `>=1.0.0` and Kaleido to `>=1.3.0`, with the refreshed `uv.lock` resolver output for their current dependency trees.
- Fix Plotly/Kaleido image export by leaving `pio.defaults.plotlyjs` unset; Kaleido 1.3 treats the old `"auto"` value as a filesystem path.
- Add Chromium to the Docker image and set `BROWSER_PATH=/usr/bin/chromium` so Kaleido v1 image export works in containers.
- Add direct `pytest-timeout` dev coverage because CI invokes pytest with `--timeout=60`.
- Adjust empty DataFrame construction to use `pd.Index(...)` for pandas 2.3.3 typing compatibility.
- Add regression coverage for the Plotly config behavior.

Supersedes #167 and #171.

## Validation
- `uv lock --check`
- Kaleido PNG export smoke test
- VectorBT portfolio smoke test
- `uv run pytest tests/test_plotly_config.py tests/unit/test_signal_backtest_adapter.py -q` - 19 passed
- `uv run ruff check maverick_mcp/providers/stock_data.py maverick_mcp/domain/stock_analysis/stock_analysis_service.py maverick_mcp/config/plotly_config.py tests/test_plotly_config.py`
- `uv run ruff format --check maverick_mcp/providers/stock_data.py maverick_mcp/domain/stock_analysis/stock_analysis_service.py maverick_mcp/config/plotly_config.py tests/test_plotly_config.py`
- `uv run ty check maverick_mcp/providers/stock_data.py maverick_mcp/domain/stock_analysis/stock_analysis_service.py` - all checks passed
- `uv run ty check maverick_mcp/services maverick_mcp/domain` - all checks passed
- `uv run pytest -m "not integration and not slow and not external" --maxfail=5 --timeout=60` - 900 passed, 4 skipped, 664 deselected, 49 warnings
- `uv run pytest tests/test_plotly_config.py -q` - 1 passed
- `docker build --progress=plain -t maverick-mcp:dependency-pr-integration .`
- Container Kaleido smoke: `docker run --rm --entrypoint /app/.venv/bin/python maverick-mcp:dependency-pr-integration -c ...` wrote a PNG with `BROWSER_PATH=/usr/bin/chromium`
- `make test` - 900 passed, 4 skipped, 664 deselected, 49 warnings