### PR TITLE
fix: expose portfolio name for correlation analysis

### DIFF
--- a/maverick_mcp/api/server.py
+++ b/maverick_mcp/api/server.py
@@ -1238,13 +1238,17 @@ async def remove_portfolio_position(
 
 
 @mcp.tool()
-async def portfolio_correlation_analysis(days: int = 252) -> dict[str, Any]:
+async def portfolio_correlation_analysis(
+    days: int = 252,
+    portfolio_name: str = "My Portfolio",
+) -> dict[str, Any]:
     """Analyze correlation between all portfolio holdings.
 
     Auto-detects your portfolio positions. No need to specify tickers.
 
     Args:
         days: Number of trading days for correlation window (default 252 = ~1 year)
+        portfolio_name: Portfolio name to analyze (default "My Portfolio")
     """
     import asyncio
 
@@ -1257,7 +1261,7 @@ async def portfolio_correlation_analysis(days: int = 252) -> dict[str, Any]:
         tickers=None,
         days=days,
         user_id="default",
-        portfolio_name="My Portfolio",
+        portfolio_name=portfolio_name,
     )
 
 

--- a/maverick_mcp/tests/test_portfolio_correlation_wrapper.py
+++ b/maverick_mcp/tests/test_portfolio_correlation_wrapper.py
@@ -1,0 +1,81 @@
+"""Regression checks for the portfolio correlation MCP wrapper."""
+
+import ast
+import asyncio
+import inspect
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+
+class _FakeMCP:
+    def tool(self):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+def _portfolio_correlation_wrapper_node() -> ast.AsyncFunctionDef:
+    source = Path("maverick_mcp/api/server.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "portfolio_correlation_analysis"
+        ):
+            return node
+    raise AssertionError("portfolio_correlation_analysis wrapper not found")
+
+
+def _compile_portfolio_correlation_wrapper():
+    node = _portfolio_correlation_wrapper_node()
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    namespace = {"Any": Any, "mcp": _FakeMCP()}
+    exec(compile(module, "<portfolio_correlation_wrapper>", "exec"), namespace)
+    return namespace["portfolio_correlation_analysis"]
+
+
+def test_portfolio_correlation_analysis_exposes_portfolio_name() -> None:
+    wrapper = _compile_portfolio_correlation_wrapper()
+
+    parameter = inspect.signature(wrapper).parameters["portfolio_name"]
+
+    assert parameter.default == "My Portfolio"
+
+
+def test_portfolio_correlation_analysis_forwards_portfolio_name() -> None:
+    wrapper = _compile_portfolio_correlation_wrapper()
+    calls = []
+
+    fake_module = types.ModuleType("maverick_mcp.api.routers.portfolio")
+
+    def fake_portfolio_correlation_analysis(**kwargs):
+        calls.append(kwargs)
+        return {"portfolio": kwargs["portfolio_name"]}
+
+    fake_module.portfolio_correlation_analysis = fake_portfolio_correlation_analysis
+
+    module_name = "maverick_mcp.api.routers.portfolio"
+    previous_module = sys.modules.get(module_name)
+    sys.modules[module_name] = fake_module
+    try:
+        result = asyncio.run(wrapper(days=30, portfolio_name="Core Portfolio"))
+    finally:
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
+
+    assert result == {"portfolio": "Core Portfolio"}
+    assert calls == [
+        {
+            "tickers": None,
+            "days": 30,
+            "user_id": "default",
+            "portfolio_name": "Core Portfolio",
+        }
+    ]


### PR DESCRIPTION
## Summary

- add the missing `portfolio_name` argument to the `portfolio_correlation_analysis` MCP wrapper
- forward the selected portfolio name to the existing portfolio router instead of always using `My Portfolio`
- add a regression check that confirms a custom portfolio name is passed through to the router call

Fixes #188.

## Verification

- `/Users/fuduji/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile maverick_mcp/api/server.py maverick_mcp/tests/test_portfolio_correlation_wrapper.py`
- direct execution of `test_portfolio_correlation_analysis_exposes_portfolio_name`
- direct execution of `test_portfolio_correlation_analysis_forwards_portfolio_name`
- `.venv-light/bin/python -m pytest maverick_mcp/tests/test_portfolio_correlation_wrapper.py -q`
- `.venv-light/bin/python -m ruff check maverick_mcp/api/server.py maverick_mcp/tests/test_portfolio_correlation_wrapper.py`

## Notes

The underlying router already supports `portfolio_name`; this change only exposes and forwards it from the MCP wrapper. It does not change portfolio storage or default behavior.

The local `.venv-light` used for pytest/ruff was removed after verification so the branch remains clean.