### PR TITLE
fix(portfolio): use 'Close' column in correlation analysis (#187)

### DIFF
--- a/maverick_mcp/api/routers/portfolio.py
+++ b/maverick_mcp/api/routers/portfolio.py
@@ -551,11 +551,15 @@ def portfolio_correlation_analysis(
         high_correlation_pairs = []
         low_correlation_pairs = []
 
-        for i in range(len(tickers)):
-            for j in range(i + 1, len(tickers)):
+        # Iterate over the tickers that actually have data: a fetch failure leaves
+        # correlation_matrix smaller than the requested `tickers`, so indexing it by
+        # the original list would raise IndexError and mislabel pairs.
+        valid_tickers = list(correlation_matrix.columns)
+        for i in range(len(valid_tickers)):
+            for j in range(i + 1, len(valid_tickers)):
                 corr_val = correlation_matrix.iloc[i, j]
                 corr = float(corr_val.item() if hasattr(corr_val, "item") else corr_val)
-                pair = (tickers[i], tickers[j])
+                pair = (valid_tickers[i], valid_tickers[j])
 
                 if corr > 0.7:
                     high_correlation_pairs.append(

--- a/maverick_mcp/api/routers/portfolio.py
+++ b/maverick_mcp/api/routers/portfolio.py
@@ -502,7 +502,7 @@ def portfolio_correlation_analysis(
                     end_date.strftime("%Y-%m-%d"),
                 )
                 if not df.empty:
-                    price_data[ticker] = df["close"]
+                    price_data[ticker] = df["Close"]
                 else:
                     failed_tickers.append(ticker)
             except Exception as e:


### PR DESCRIPTION
## 📋 Pull Request Summary

**Brief description of changes:**
`portfolio_correlation_analysis` always returned "Insufficient valid price data" because it read the wrong DataFrame column, and — once that was fixed — a partial fetch failure could crash the correlation-pair loop. This PR fixes both.

**Related issue(s):**
- Fixes #187

## 💰 Financial Disclaimer Acknowledgment

- [x] I understand this is educational software and not financial advice
- [x] Any financial analysis features include appropriate disclaimers
- [x] This PR maintains the educational/personal-use focus of the project

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🎯 Component Areas

**Primary areas affected:**
- [x] Data fetching (Tiingo, Yahoo Finance, FRED)
- [x] Portfolio analysis and optimization
- [x] MCP server/tools implementation

## 🔧 Implementation Details

**Technical approach:**
`stock_provider.get_stock_data()` returns capitalized OHLCV columns (the provider renames `close -> Close`, and every other consumer in `portfolio.py` reads `df["Close"]`). The correlation loop read `df["close"]`, which raised `KeyError` for every ticker; the surrounding `except` routed all of them into `failed_tickers`, so the tool always reported insufficient data.

Fixing that surfaced a second, latent defect: the correlation matrix is built only from tickers that returned data, so a partial fetch failure makes it smaller than the requested `tickers` list. The pair loop indexed the matrix by the original list, which raised `IndexError` and mislabeled pairs. It now iterates over `correlation_matrix.columns`.

**Key changes:**
- `portfolio.py`: read per-ticker prices from `df["Close"]` (was `df["close"]`).
- `portfolio.py`: generate correlation pairs from `correlation_matrix.columns` (the fetched tickers) instead of the requested `tickers` list.

**Dependencies:**
- [x] No new dependencies added

## 🧪 Testing

**Testing performed:**
- [x] Manual testing completed

**Test scenarios covered:**
- [x] Happy path functionality
- [x] Error handling and edge cases

**Manual testing:**
- Confirmed the provider returns a `Close` column (`stock_data.py` renames `close -> Close`) and that the other reads in `portfolio.py` already use `df["Close"]`; `portfolio_correlation_analysis([...])` now returns a correlation matrix instead of "Insufficient valid price data".
- Reproduced the pair-loop defect: with a 2x2 matrix (one of three tickers failing), the old `range(len(tickers))` loop raises `IndexError: index 2 is out of bounds for axis 0 with size 2`; the `correlation_matrix.columns` loop produces the correct pairs with no error.

## 🔒 Security Considerations

- [x] No hardcoded secrets or credentials
- [x] Error handling doesn't leak sensitive information

## 📚 Documentation

- [x] Code comments added/updated
- [x] No breaking changes
