### PR TITLE
fix: restore .env loading in the server bootstrap (#218)

### DIFF
--- a/maverick/server/app.py
+++ b/maverick/server/app.py
@@ -3,6 +3,8 @@
 import argparse
 import sys
 
+from dotenv import find_dotenv, load_dotenv
+
 from maverick.platform.telemetry import get_logger, setup_logging
 from maverick.server.assembly import build_server
 
@@ -11,6 +13,29 @@ _DEFAULT_HTTP_HOST = "127.0.0.1"
 # (it only covers database/redis/cache/http-client/telemetry), so this
 # falls back to the legacy server's own default port.
 _DEFAULT_HTTP_PORT = 8003
+
+
+def _load_env_file() -> None:
+    """Apply the project's `.env` to the process environment.
+
+    `maverick.platform.config` reads settings from the process environment
+    only, so the `.env` has to be applied before anything resolves settings --
+    this is the bootstrap path that owns that, which is why it runs here rather
+    than as an import side effect in a library module.
+
+    The search is anchored at the current working directory because that is
+    what both documented launch paths use: `make dev` runs from the project
+    root, and the Claude Desktop config in CLAUDE.md sets `"cwd"` to the
+    checkout. Anchoring on this file instead would miss the `.env` whenever the
+    package is installed outside the project tree.
+
+    Real environment variables win: `load_dotenv` does not override values that
+    are already set, so an explicit `DATABASE_URL=... make dev` still takes
+    precedence over the file. Missing `.env` is a no-op.
+    """
+    dotenv_path = find_dotenv(usecwd=True)
+    if dotenv_path:
+        load_dotenv(dotenv_path)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -48,6 +73,7 @@ def main(argv: list[str] | None = None) -> None:
     can offer that.
     """
     args = _parse_args(argv)
+    _load_env_file()
     setup_logging()
     logger = get_logger("maverick.server")
 

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -6,9 +6,33 @@ raise, and its happy path is exercised only up to the `mcp.run(...)` call by
 monkeypatching that away too.
 """
 
+import os
+
 import pytest
 
 from maverick.server import app
+
+_PROBE = "MAVERICK_TEST_DOTENV_PROBE"
+
+
+@pytest.fixture
+def restore_environ():
+    """Restore `os.environ` around tests that let `load_dotenv` mutate it.
+
+    `load_dotenv` writes to `os.environ` directly rather than through
+    monkeypatch, so those writes are not undone automatically.
+    """
+    snapshot = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(snapshot)
+
+
+class _FakeMCP:
+    """Stands in for the assembled server so `main()` never starts a transport."""
+
+    def run(self, *args, **kwargs):
+        pass
 
 
 def test_transport_defaults_to_stdio():
@@ -79,3 +103,70 @@ def test_main_http_calls_run_with_host_and_port(monkeypatch):
     assert calls == [
         ((), {"transport": "http", "host": app._DEFAULT_HTTP_HOST, "port": 9200})
     ]
+
+
+def test_main_applies_env_file_before_building_server(
+    monkeypatch, tmp_path, restore_environ
+):
+    """The `.env` reaches the process environment before settings are resolved.
+
+    `build_server()` is where `get_platform_settings()` first runs, so reading
+    the variable at that moment is what proves the file was applied early
+    enough to affect `DATABASE_URL`, `REDIS_HOST`, and the rest.
+    """
+    (tmp_path / ".env").write_text(f"{_PROBE}=from-env-file\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(_PROBE, raising=False)
+
+    seen: list[str | None] = []
+
+    def _build():
+        seen.append(os.environ.get(_PROBE))
+        return _FakeMCP()
+
+    monkeypatch.setattr(app, "build_server", _build)
+
+    app.main([])
+
+    assert seen == ["from-env-file"]
+
+
+def test_main_does_not_override_the_real_environment(
+    monkeypatch, tmp_path, restore_environ
+):
+    """A variable already set in the environment beats the `.env` value."""
+    (tmp_path / ".env").write_text(f"{_PROBE}=from-env-file\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(_PROBE, "from-real-environment")
+
+    seen: list[str | None] = []
+
+    def _build():
+        seen.append(os.environ.get(_PROBE))
+        return _FakeMCP()
+
+    monkeypatch.setattr(app, "build_server", _build)
+
+    app.main([])
+
+    assert seen == ["from-real-environment"]
+
+
+def test_main_without_an_env_file_starts_normally(
+    monkeypatch, tmp_path, restore_environ
+):
+    """A missing `.env` is a no-op, not a startup failure."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(_PROBE, raising=False)
+
+    seen: list[str | None] = []
+
+    def _build():
+        seen.append(os.environ.get(_PROBE))
+        return _FakeMCP()
+
+    monkeypatch.setattr(app, "build_server", _build)
+
+    app.main([])
+
+    assert seen == [None]


### PR DESCRIPTION
Fixes #218.

## Root cause

`1637f60` (*refactor!: delete legacy maverick_mcp package*) removed the package that held the only `load_dotenv()` call, and the new `maverick/server/` package never got an equivalent bootstrap. `maverick/platform/config.py` is explicit that it reads the process environment only, so with nothing populating it from `.env`, every value in that file is silently ignored.

Confirmed on current `main` (`b637989`): `grep -rn dotenv maverick/` returns nothing, while `python-dotenv>=1.2.2` is still declared in `pyproject.toml:18` — which is what makes the gap easy to miss.

The failure is silent, which is the costly part: the yfinance-backed tools (`market_data_*`, `technical_*`) need no configuration and keep working, so the server looks healthy while DB-, cache- and research-backed tools quietly fall back to defaults.

Affected launch paths — every documented non-container one:

| Launch path | `.env` applied before | after |
|---|---|---|
| `make dev` / `make dev-stdio` | ❌ | ✅ |
| Claude Desktop stdio config (`CLAUDE.md`) | ❌ | ✅ |
| `docker run --env-file .env` | ✅ | ✅ (unchanged) |

## The fix

Option (a) from the issue, with one adjustment.

The issue suggests `maverick/server/__main__.py`. I put it in `main()` in `app.py` instead, because `pyproject.toml:82-83` points both console scripts (`maverick-mcp`, `maverick-mcp-server`) at `maverick.server.app:main` — `__main__.py` alone would fix `python -m maverick.server` but leave the console scripts broken. Every entry point routes through `main()`.

It runs inside `main()` rather than at module level, to preserve the no-import-side-effects rule the cutover established. That is also what the modernization spec asked for in the first place:

> "module-level `load_dotenv()` and `logging.basicConfig()` side effects are removed from library modules and **centralized in the server bootstrap path**"

`main()` is that bootstrap path. Placing the call before `setup_logging()` and `build_server()` means it lands before anything resolves settings — `get_platform_settings()` is `lru_cache`d and first runs inside `build_server()` (`assembly.py:55`), and no module reads settings at import time, so nothing can cache a pre-`.env` value.

The search is anchored at the working directory (`find_dotenv(usecwd=True)`) rather than at this file, because both documented launch paths already put the cwd at the checkout — `make dev` runs from the project root, and the Desktop config in `CLAUDE.md:31` sets `"cwd"` to it. Anchoring on the module would silently miss the `.env` whenever the package is installed outside the project tree.

Behavior kept conservative: real environment variables still win (`load_dotenv` does not override what is already set, so `DATABASE_URL=... make dev` still takes precedence), and a missing `.env` is a no-op rather than a startup error.

## Testing

Three tests in `tests/server/test_app.py`, following the existing convention there of never letting `mcp.run(...)` start a real transport:

- `test_main_applies_env_file_before_building_server` — the regression test. Reads the probe variable at the moment `build_server()` is called, which is where settings first resolve. **Verified failing on unfixed `main`** (`assert [None] == ['from-env-file']`), passing with the fix.
- `test_main_does_not_override_the_real_environment` — guard against over-fixing with `override=True`.
- `test_main_without_an_env_file_starts_normally` — a missing `.env` must not become a startup failure.

Full suite: **902 passed, 19 skipped** (899 passed before this change — the 3 new tests). The 12 `tests/research/` failures are pre-existing and unrelated; I confirmed the identical 12 fail on a clean `main` checkout.

`ruff check`, `ruff format --check`, and `pyright` are all clean on both changed files.