### PR TITLE
feat(portfolio): auto-tag positions with GICS sector and surface sector exposure

### DIFF
--- a/docs/features/portfolio.md
+++ b/docs/features/portfolio.md
@@ -64,6 +64,18 @@ new_total_cost = new_shares * average_cost_basis
 
 When all shares are removed, the position row is removed.
 
+## Sector Tagging
+
+`portfolio_add_position` best-effort populates each position's GICS sector
+from yfinance fundamentals. Provider failures store `NULL` and never block
+the position write; existing databases gain the nullable sector column
+automatically at startup.
+
+Positions without a sector surface as `Unknown`. Portfolio snapshots expose
+`sector_exposure` as the fraction of portfolio value in each sector. The risk
+dashboard keeps the `Unknown` concentration bucket visible, but that bucket
+never produces a sector-concentration alert.
+
 ## Precision Rules
 
 - Use `Decimal` for financial calculations.

--- a/maverick/platform/db.py
+++ b/maverick/platform/db.py
@@ -30,8 +30,12 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import NullPool, QueuePool
+from sqlalchemy.schema import CreateColumn
 
 from maverick.platform.config import DatabaseSettings
+from maverick.platform.telemetry import get_logger
+
+logger = get_logger(__name__)
 
 # Legacy default: seconds to wait for a new TCP connection before giving up.
 _POSTGRES_CONNECT_TIMEOUT_SECONDS = 10
@@ -165,7 +169,7 @@ _schema_created: "weakref.WeakKeyDictionary[Engine, set[str]]" = (
 
 
 def ensure_schema(engine: Engine, metadata: MetaData, *, force: bool = False) -> bool:
-    """Ensure ``metadata``'s tables exist on ``engine``, lazily and once.
+    """Ensure ``metadata``'s tables and nullable columns exist, lazily and once.
 
     Memoizes per ``(engine, table name)`` so repeat calls for a metadata
     whose tables are already known-present are a set-membership check, not a
@@ -174,9 +178,15 @@ def ensure_schema(engine: Engine, metadata: MetaData, *, force: bool = False) ->
     tables created on its first call. Pass ``force=True`` to bypass the
     memoized fast path and re-run ``create_all`` unconditionally.
 
+    Existing tables gain plain nullable columns defined by ``metadata``
+    through portable SQLAlchemy column compilation. Missing non-nullable or
+    constrained columns are skipped with a warning because they require a
+    data-migration policy. Each ALTER is isolated; a concurrent migration
+    race logs a warning without preventing startup or later column attempts.
+
     Returns:
-        ``True`` if table creation was executed, ``False`` if the schema
-        was already known to be present.
+        ``True`` if schema DDL was executed, ``False`` if the schema was
+        already known to be present.
     """
     defined_tables = set(metadata.tables.keys())
     known_tables = _schema_created.get(engine, set())
@@ -191,17 +201,70 @@ def ensure_schema(engine: Engine, metadata: MetaData, *, force: bool = False) ->
         try:
             inspector = inspect(engine)
             existing_tables = set(inspector.get_table_names())
+            existing_columns = {
+                table_name: {
+                    column["name"] for column in inspector.get_columns(table_name)
+                }
+                for table_name in defined_tables & existing_tables
+            }
         except SQLAlchemyError:
             existing_tables = set()
+            existing_columns = {}
 
         missing_tables = defined_tables - existing_tables
+        missing_columns = [
+            (metadata.tables[table_name], column)
+            for table_name, column_names in existing_columns.items()
+            for column in metadata.tables[table_name].columns
+            if column.name not in column_names
+        ]
+        columns_to_add = []
+        for table, column in missing_columns:
+            if (
+                not column.nullable
+                or column.foreign_keys
+                or column.unique
+                or column.index
+                or column.primary_key
+            ):
+                logger.warning(
+                    "database: skipping automatic add for missing column %s.%s; "
+                    "column is non-nullable or constrained",
+                    table.fullname,
+                    column.name,
+                )
+                continue
+            columns_to_add.append((table, column))
 
         should_create = force or bool(missing_tables)
         if should_create:
             metadata.create_all(bind=engine)
 
+        columns_added = False
+        if columns_to_add:
+            preparer = engine.dialect.identifier_preparer
+            for table, column in columns_to_add:
+                try:
+                    table_ddl = preparer.format_table(table)
+                    column_ddl = str(
+                        CreateColumn(column).compile(dialect=engine.dialect)
+                    )
+                    with engine.begin() as connection:
+                        connection.exec_driver_sql(
+                            f"ALTER TABLE {table_ddl} ADD COLUMN {column_ddl}"
+                        )
+                except SQLAlchemyError:
+                    logger.warning(
+                        "database: failed to add missing column %s.%s",
+                        table.fullname,
+                        column.name,
+                        exc_info=True,
+                    )
+                    continue
+                columns_added = True
+
         _schema_created[engine] = known_tables | defined_tables
-        return should_create
+        return should_create or columns_added
 
 
 @contextmanager

--- a/maverick/portfolio/data.py
+++ b/maverick/portfolio/data.py
@@ -76,6 +76,7 @@ PF_POSITIONS = Table(
     Column("total_cost", Numeric(20, 4), nullable=False),
     Column("purchase_date", DateTime(timezone=True), nullable=False),
     Column("notes", Text, nullable=True),
+    Column("sector", String(100), nullable=True),
     UniqueConstraint(
         "portfolio_id", "ticker", name="pf_positions_portfolio_ticker_unique"
     ),
@@ -146,6 +147,7 @@ def _position_values(position: PositionPayload) -> dict[str, object]:
         "total_cost": Decimal(str(position.total_cost)),
         "purchase_date": _purchase_date_to_datetime(position.purchase_date),
         "notes": position.notes,
+        "sector": position.sector,
     }
 
 
@@ -157,6 +159,7 @@ def _row_to_position(row) -> PositionPayload:  # noqa: ANN001
         total_cost=Decimal(str(row.total_cost)),
         purchase_date=_datetime_to_purchase_date(row.purchase_date),
         notes=row.notes,
+        sector=row.sector,
     )
 
 

--- a/maverick/portfolio/ledger.py
+++ b/maverick/portfolio/ledger.py
@@ -124,9 +124,7 @@ def find_position(
     positions: list[PositionPayload], ticker: str
 ) -> PositionPayload | None:
     """Return the position for ``ticker`` in ``positions``, or None."""
-    return next(
-        (position for position in positions if position.ticker == ticker), None
-    )
+    return next((position for position in positions if position.ticker == ticker), None)
 
 
 def position_value(

--- a/maverick/portfolio/ledger.py
+++ b/maverick/portfolio/ledger.py
@@ -9,7 +9,12 @@ string (never reformatted), so callers' formatting is preserved verbatim.
 from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 
-from maverick.portfolio.types import PortfolioMetrics, PositionPayload, RemoveResult
+from maverick.portfolio.types import (
+    PortfolioMetrics,
+    PositionPayload,
+    PositionWithPrice,
+    RemoveResult,
+)
 
 _BASIS_QUANT = Decimal("0.0001")
 _MONEY_QUANT = Decimal("0.01")
@@ -26,6 +31,7 @@ def add_shares(
     price: Decimal,
     purchase_date: str,
     notes: str | None = None,
+    sector: str | None = None,
 ) -> PositionPayload:
     """Add shares to `position` (or create one if `position` is None).
 
@@ -51,6 +57,7 @@ def add_shares(
             total_cost=shares * price,
             purchase_date=purchase_date,
             notes=notes,
+            sector=sector,
         )
 
     new_total_shares = position.shares + shares
@@ -71,6 +78,7 @@ def add_shares(
         total_cost=new_total_cost,
         purchase_date=earliest_date,
         notes=position.notes,
+        sector=position.sector or sector,
     )
 
 
@@ -103,11 +111,21 @@ def remove_shares(
         total_cost=new_shares * position.average_cost_basis,
         purchase_date=position.purchase_date,
         notes=position.notes,
+        sector=position.sector,
     )
     return updated, RemoveResult(
         ticker=position.ticker,
         shares_removed=shares,
         position_fully_closed=False,
+    )
+
+
+def find_position(
+    positions: list[PositionPayload], ticker: str
+) -> PositionPayload | None:
+    """Return the position for ``ticker`` in ``positions``, or None."""
+    return next(
+        (position for position in positions if position.ticker == ticker), None
     )
 
 
@@ -166,3 +184,73 @@ def portfolio_metrics(
         total_pnl_percent=float(total_pnl_percent),
         position_count=len(positions),
     )
+
+
+def portfolio_snapshot_values(
+    positions: list[PositionPayload], prices: dict[str, Decimal]
+) -> tuple[list[PositionWithPrice], PortfolioMetrics, dict[str, float]]:
+    """Build priced positions, aggregate metrics, and sector exposure.
+
+    Failed quotes leave per-position price fields empty while metrics and
+    sector exposure fall back to average cost basis.
+    """
+    positions_with_price: list[PositionWithPrice] = []
+    sector_values: dict[str, Decimal] = {}
+    total_value = Decimal("0")
+    total_cost = Decimal("0")
+    sector_total_value = Decimal("0")
+
+    for position in positions:
+        price = prices.get(position.ticker)
+        exposure_price = price if price is not None else position.average_cost_basis
+        exposure_value = position.shares * exposure_price
+        value, pnl, pnl_percent = position_value(position, exposure_price)
+        sector = position.sector or "Unknown"
+        sector_values[sector] = sector_values.get(sector, Decimal("0")) + exposure_value
+        total_value += value
+        total_cost += position.total_cost
+        sector_total_value += exposure_value
+
+        if price is None:
+            positions_with_price.append(
+                PositionWithPrice(
+                    **position.model_dump(),
+                    current_price=None,
+                    current_value=None,
+                    unrealized_pnl=None,
+                    unrealized_pnl_percent=None,
+                )
+            )
+            continue
+        positions_with_price.append(
+            PositionWithPrice(
+                **position.model_dump(),
+                current_price=float(price),
+                current_value=float(value),
+                unrealized_pnl=float(pnl),
+                unrealized_pnl_percent=float(pnl_percent),
+            )
+        )
+
+    sector_exposure = (
+        {
+            sector: round(float(value / sector_total_value), 4)
+            for sector, value in sector_values.items()
+        }
+        if sector_total_value > 0
+        else {}
+    )
+    total_pnl = total_value - total_cost
+    total_pnl_percent = (
+        (total_pnl / total_cost * 100).quantize(_MONEY_QUANT, rounding=ROUND_HALF_UP)
+        if total_cost > 0
+        else Decimal("0.00")
+    )
+    metrics = PortfolioMetrics(
+        total_invested=total_cost,
+        total_value=float(total_value),
+        total_pnl=float(total_pnl),
+        total_pnl_percent=float(total_pnl_percent),
+        position_count=len(positions),
+    )
+    return positions_with_price, metrics, sector_exposure

--- a/maverick/portfolio/risk.py
+++ b/maverick/portfolio/risk.py
@@ -18,9 +18,10 @@ are advisory floats, matching legacy and the existing `analysis.py`
 outputs -- positions feeding this module have already round-tripped
 through the Decimal ledger upstream in the service tier.
 
-Sector: portfolio positions do not carry sector data (Phase 4 decision:
-"sector info not stored on position"), so every `PositionExposure.sector`
-is "Unknown" in practice, exactly as the legacy router hardcoded it.
+Sector: portfolio positions carry an optional persisted GICS sector. NULL
+values remain visible in dashboard concentration as "Unknown", but that
+bucket is skipped by concentration alerts because missing classifications
+are not evidence of actual sector concentration.
 """
 
 import math
@@ -136,6 +137,7 @@ def check_position_risk(
     new_shares: float,
     new_price: float,
     settings: PortfolioSettings,
+    new_sector: str | None = None,
 ) -> PositionRiskCheck:
     """Current vs. projected dashboard after merging in a prospective new
     (or added-to, if `new_symbol` is already held) position."""
@@ -158,6 +160,7 @@ def check_position_risk(
                         "shares": total_shares,
                         "cost_basis": avg_cost,
                         "current_price": new_price,
+                        "sector": new_sector or pos.sector,
                     }
                 )
             )
@@ -171,7 +174,7 @@ def check_position_risk(
                 shares=new_shares,
                 cost_basis=new_price,
                 current_price=new_price,
-                sector="Unknown",
+                sector=new_sector or "Unknown",
             )
         )
 
@@ -244,6 +247,8 @@ def generate_alerts(
     total_value = dashboard.total_value
 
     for sector, pct in dashboard.sector_concentration.items():
+        if sector == "Unknown":
+            continue
         if pct > settings.risk_sector_critical_pct:
             alerts.append(
                 RiskAlert(

--- a/maverick/portfolio/service.py
+++ b/maverick/portfolio/service.py
@@ -41,16 +41,19 @@ from maverick.portfolio.data import (
     read_positions,
     upsert_position,
 )
-from maverick.portfolio.ledger import add_shares, portfolio_metrics, position_value
+from maverick.portfolio.ledger import (
+    add_shares,
+    find_position,
+    portfolio_snapshot_values,
+    position_value,
+)
 from maverick.portfolio.ledger import remove_shares as ledger_remove_shares
 from maverick.portfolio.types import (
     ComparisonResult,
     CorrelationResult,
-    PortfolioMetrics,
     PortfolioSnapshot,
     PositionPayload,
     PositionRiskCheck,
-    PositionWithPrice,
     RegimeAdjustedSizing,
     RemoveResult,
     RiskAlertsResult,
@@ -158,20 +161,31 @@ class PortfolioService:
         resolved_date = self._normalize_purchase_date(
             purchase_date or date.today().isoformat()
         )
+        # Pre-read only gates the slow sector lookup; the merge re-reads inside
+        # the write transaction so a concurrent add can't be lost to staleness.
+        pre_read = find_position(
+            await self._read_positions(user_id, portfolio_name), normalized_ticker
+        )
+        sector = None
+        if pre_read is None or pre_read.sector is None:
+            sector = await service_risk.resolve_sector(
+                self._market_data, normalized_ticker
+            )
 
         def _write() -> PositionPayload:
             with session_scope(self._session_factory) as session:
                 portfolio_id = get_or_create_portfolio(session, user_id, portfolio_name)
-                existing = next(
-                    (
-                        p
-                        for p in read_positions(session, portfolio_id)
-                        if p.ticker == normalized_ticker
-                    ),
-                    None,
+                existing = find_position(
+                    read_positions(session, portfolio_id), normalized_ticker
                 )
                 updated = add_shares(
-                    existing, normalized_ticker, shares, price, resolved_date, notes
+                    existing,
+                    normalized_ticker,
+                    shares,
+                    price,
+                    resolved_date,
+                    notes,
+                    sector,
                 )
                 upsert_position(session, portfolio_id, updated)
                 return updated
@@ -191,13 +205,8 @@ class PortfolioService:
         def _write() -> RemoveResult:
             with session_scope(self._session_factory) as session:
                 portfolio_id = get_or_create_portfolio(session, user_id, portfolio_name)
-                existing = next(
-                    (
-                        p
-                        for p in read_positions(session, portfolio_id)
-                        if p.ticker == normalized_ticker
-                    ),
-                    None,
+                existing = find_position(
+                    read_positions(session, portfolio_id), normalized_ticker
                 )
                 if existing is None:
                     raise ValueError(
@@ -261,38 +270,16 @@ class PortfolioService:
         positions = await self._read_positions(user_id, portfolio_name)
         prices = await self._fetch_quote_prices([p.ticker for p in positions])
 
-        positions_with_price: list[PositionWithPrice] = []
-        for position in positions:
-            price = prices.get(position.ticker)
-            if price is None:
-                positions_with_price.append(
-                    PositionWithPrice(
-                        **position.model_dump(),
-                        current_price=None,
-                        current_value=None,
-                        unrealized_pnl=None,
-                        unrealized_pnl_percent=None,
-                    )
-                )
-                continue
-            value, pnl, pnl_percent = position_value(position, price)
-            positions_with_price.append(
-                PositionWithPrice(
-                    **position.model_dump(),
-                    current_price=float(price),
-                    current_value=float(value),
-                    unrealized_pnl=float(pnl),
-                    unrealized_pnl_percent=float(pnl_percent),
-                )
-            )
-
-        metrics: PortfolioMetrics = portfolio_metrics(positions, prices)
+        positions_with_price, metrics, sector_exposure = portfolio_snapshot_values(
+            positions, prices
+        )
 
         return PortfolioSnapshot(
             user_id=user_id,
             name=portfolio_name,
             positions=positions_with_price,
             metrics=metrics,
+            sector_exposure=sector_exposure,
             as_of=datetime.now(UTC).isoformat(),
         )
 
@@ -441,9 +428,21 @@ class PortfolioService:
         await self._ensure_schema()
         normalized_ticker = self._normalize_ticker(ticker)
         positions = await self._read_positions(user_id, portfolio_name)
+        existing = find_position(positions, normalized_ticker)
+        new_sector = existing.sector if existing is not None else None
+        if new_sector is None:
+            new_sector = await service_risk.resolve_sector(
+                self._market_data, normalized_ticker
+            )
         prices = await self._fetch_quote_prices([p.ticker for p in positions])
         return service_risk.check_position_risk(
-            positions, prices, normalized_ticker, shares, entry_price, self._settings
+            positions,
+            prices,
+            normalized_ticker,
+            shares,
+            entry_price,
+            self._settings,
+            new_sector,
         )
 
     async def get_regime_adjusted_sizing(

--- a/maverick/portfolio/service_risk.py
+++ b/maverick/portfolio/service_risk.py
@@ -27,6 +27,25 @@ from maverick.portfolio.types import (
 logger = get_logger(__name__)
 
 
+async def resolve_sector(market_data: MarketDataService, ticker: str) -> str | None:
+    """Best-effort GICS sector for `ticker` via fundamentals; any provider
+    failure returns None (the position write must never depend on yfinance),
+    and an empty/whitespace sector normalizes to None."""
+    try:
+        fundamentals = await market_data.get_fundamentals(ticker)
+        sector = fundamentals.company.sector
+        if sector is None:
+            return None
+        return sector.strip() or None
+    except Exception:
+        logger.warning(
+            "portfolio: failed to fetch sector for %s, storing None",
+            ticker,
+            exc_info=True,
+        )
+        return None
+
+
 def positions_to_exposures(
     positions: list[PositionPayload], prices: dict[str, Decimal]
 ) -> list[PositionExposure]:
@@ -34,8 +53,8 @@ def positions_to_exposures(
     ticker missing from `prices` (failed quote) falls back to its own
     average cost basis -- never dropped, unlike `get_portfolio`'s None
     price fields -- matching the legacy risk-dashboard router's position
-    fetch. Sector is always "Unknown": not tracked on positions (Phase 4
-    decision)."""
+    fetch. A position whose persisted sector is NULL stays in the
+    "Unknown" dashboard bucket."""
     return [
         PositionExposure(
             symbol=position.ticker,
@@ -44,7 +63,7 @@ def positions_to_exposures(
             current_price=float(
                 prices.get(position.ticker, position.average_cost_basis)
             ),
-            sector="Unknown",
+            sector=position.sector or "Unknown",
         )
         for position in positions
     ]
@@ -66,9 +85,12 @@ def check_position_risk(
     shares: float,
     entry_price: float,
     settings: PortfolioSettings,
+    new_sector: str | None = None,
 ) -> PositionRiskCheck:
     exposures = positions_to_exposures(positions, prices)
-    return risk.check_position_risk(exposures, ticker, shares, entry_price, settings)
+    return risk.check_position_risk(
+        exposures, ticker, shares, entry_price, settings, new_sector
+    )
 
 
 async def detect_market_regime(

--- a/maverick/portfolio/types.py
+++ b/maverick/portfolio/types.py
@@ -13,6 +13,7 @@ class PositionPayload(BaseModel):
     total_cost: Decimal = Field(gt=0)
     purchase_date: str
     notes: str | None = None
+    sector: str | None = None
 
 
 class PositionWithPrice(PositionPayload):
@@ -35,6 +36,7 @@ class PortfolioSnapshot(BaseModel):
     name: str
     positions: list[PositionWithPrice]
     metrics: PortfolioMetrics
+    sector_exposure: dict[str, float]
     as_of: str
 
 
@@ -88,9 +90,7 @@ class RiskAnalysis(BaseModel):
 class PositionExposure(BaseModel):
     """A position's risk-computation inputs: `risk.py`'s pure functions take
     lists of these, never `PositionPayload`/ledger types directly. `sector`
-    defaults to "Unknown" because positions do not carry sector data (Phase
-    4 decision), matching the legacy risk-dashboard router's hardcoded
-    placeholder."""
+    defaults to "Unknown" for positions whose persisted sector is NULL."""
 
     symbol: str
     shares: float

--- a/tests/platform/test_db.py
+++ b/tests/platform/test_db.py
@@ -1,6 +1,7 @@
 """Tests for maverick.platform.db."""
 
 import gc
+import logging
 
 import pytest
 import sqlalchemy
@@ -74,6 +75,70 @@ def test_ensure_schema_is_lazy_and_idempotent(tmp_path):
     assert ensure_schema(engine, METADATA) is True
     assert ensure_schema(engine, METADATA) is False
     assert ensure_schema(engine, METADATA, force=True) is True
+
+
+def test_ensure_schema_adds_plain_nullable_column_and_skips_indexed_column(
+    tmp_path, caplog
+):
+    old_metadata = MetaData()
+    Table("legacy_items", old_metadata, Column("id", Integer, primary_key=True))
+    desired_metadata = MetaData()
+    Table(
+        "legacy_items",
+        desired_metadata,
+        Column("id", Integer, primary_key=True),
+        Column("sector", String(100), nullable=True),
+        Column("lookup_key", String(100), nullable=True, index=True),
+    )
+    engine = create_engine_from_settings(_settings(tmp_path))
+    old_metadata.create_all(engine)
+
+    with caplog.at_level(logging.WARNING):
+        assert ensure_schema(engine, desired_metadata) is True
+    assert {
+        column["name"] for column in inspect(engine).get_columns("legacy_items")
+    } == {
+        "id",
+        "sector",
+    }
+    assert any("legacy_items.lookup_key" in message for message in caplog.messages)
+    assert ensure_schema(engine, desired_metadata) is False
+
+
+def test_ensure_schema_continues_after_one_column_alter_fails(
+    tmp_path, monkeypatch, caplog
+):
+    old_metadata = MetaData()
+    Table("race_items", old_metadata, Column("id", Integer, primary_key=True))
+    desired_metadata = MetaData()
+    Table(
+        "race_items",
+        desired_metadata,
+        Column("id", Integer, primary_key=True),
+        Column("raced_column", String(100), nullable=True),
+        Column("later_column", String(100), nullable=True),
+    )
+    engine = create_engine_from_settings(_settings(tmp_path))
+    old_metadata.create_all(engine)
+    original_exec_driver_sql = sqlalchemy.engine.Connection.exec_driver_sql
+
+    def flaky_exec_driver_sql(connection, statement, *args, **kwargs):
+        if statement.startswith("ALTER TABLE") and "raced_column" in statement:
+            raise sqlalchemy.exc.SQLAlchemyError("concurrent migration")
+        return original_exec_driver_sql(connection, statement, *args, **kwargs)
+
+    monkeypatch.setattr(
+        sqlalchemy.engine.Connection, "exec_driver_sql", flaky_exec_driver_sql
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert ensure_schema(engine, desired_metadata) is True
+
+    assert {column["name"] for column in inspect(engine).get_columns("race_items")} == {
+        "id",
+        "later_column",
+    }
+    assert any("race_items.raced_column" in message for message in caplog.messages)
 
 
 def test_ensure_schema_creates_a_second_metadatas_tables_on_a_shared_engine(tmp_path):

--- a/tests/portfolio/test_data.py
+++ b/tests/portfolio/test_data.py
@@ -153,6 +153,28 @@ def test_upsert_then_read_preserves_total_cost_exactly(factory):
     assert positions[0].total_cost == Decimal("1062.7259")
 
 
+def test_upsert_then_read_preserves_sector(factory):
+    with session_scope(factory) as session:
+        portfolio_id = get_or_create_portfolio(session, "default", "My Portfolio")
+        upsert_position(session, portfolio_id, _position(sector="Technology"))
+
+    with session_scope(factory) as session:
+        positions = read_positions(session, portfolio_id)
+
+    assert positions[0].sector == "Technology"
+
+
+def test_read_positions_maps_null_sector_to_none(factory):
+    with session_scope(factory) as session:
+        portfolio_id = get_or_create_portfolio(session, "default", "My Portfolio")
+        upsert_position(session, portfolio_id, _position(sector=None))
+
+    with session_scope(factory) as session:
+        positions = read_positions(session, portfolio_id)
+
+    assert positions[0].sector is None
+
+
 # -- read_positions -----------------------------------------------------------
 
 

--- a/tests/portfolio/test_ledger.py
+++ b/tests/portfolio/test_ledger.py
@@ -36,6 +36,7 @@ def _position(
     total_cost: str = "1500.00",
     purchase_date: str = "2026-01-01",
     notes: str | None = None,
+    sector: str | None = None,
 ) -> PositionPayload:
     return PositionPayload(
         ticker=ticker,
@@ -44,6 +45,7 @@ def _position(
         total_cost=Decimal(total_cost),
         purchase_date=purchase_date,
         notes=notes,
+        sector=sector,
     )
 
 
@@ -142,6 +144,34 @@ class TestAddSharesExistingPosition:
 
         assert pos.notes == "Original notes"
 
+    def test_keeps_existing_sector_when_new_lot_has_fresh_sector(self):
+        pos = _position(sector="Technology")
+
+        pos = add_shares(
+            pos,
+            "AAPL",
+            Decimal("10"),
+            Decimal("170.00"),
+            "2026-01-02",
+            sector="Consumer Cyclical",
+        )
+
+        assert pos.sector == "Technology"
+
+    def test_adopts_new_sector_when_existing_sector_is_null(self):
+        pos = _position(sector=None)
+
+        pos = add_shares(
+            pos,
+            "AAPL",
+            Decimal("10"),
+            Decimal("170.00"),
+            "2026-01-02",
+            sector="Technology",
+        )
+
+        assert pos.sector == "Technology"
+
     def test_rejects_zero_shares(self):
         pos = _position()
 
@@ -185,7 +215,12 @@ class TestAddSharesExistingPosition:
 
 class TestRemoveShares:
     def test_partial_removal_keeps_basis(self):
-        pos = _position(shares="20", average_cost_basis="160.00", total_cost="3200.00")
+        pos = _position(
+            shares="20",
+            average_cost_basis="160.00",
+            total_cost="3200.00",
+            sector="Technology",
+        )
 
         updated, result = remove_shares(pos, Decimal("10"))
 
@@ -193,6 +228,7 @@ class TestRemoveShares:
         assert updated.shares == Decimal("10")
         assert updated.average_cost_basis == Decimal("160.00")  # unchanged
         assert updated.total_cost == Decimal("1600.00")
+        assert updated.sector == "Technology"
         assert result.ticker == "AAPL"
         assert result.shares_removed == Decimal("10")
         assert result.position_fully_closed is False

--- a/tests/portfolio/test_risk.py
+++ b/tests/portfolio/test_risk.py
@@ -205,6 +205,14 @@ def test_generate_alerts_sector_concentration_critical_and_warning():
     assert concentration["Financial"].severity == "warning"
 
 
+def test_generate_alerts_unknown_sector_never_creates_concentration_alert():
+    positions = [_exposure("AAPL", 10, 100, 100)]
+
+    alerts = generate_alerts(positions, _SETTINGS)
+
+    assert not any(alert.alert_type == "concentration" for alert in alerts)
+
+
 def test_generate_alerts_oversized_position_warning():
     # AAPL = 1500/2500 = 60% > 20% position warn threshold.
     positions = [

--- a/tests/portfolio/test_service.py
+++ b/tests/portfolio/test_service.py
@@ -6,6 +6,7 @@ including one symbol that always fails, to exercise the "never fatal"
 partial-failure paths.
 """
 
+import logging
 import math
 from datetime import date
 from decimal import Decimal
@@ -14,7 +15,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from maverick.market_data.types import Quote
+from maverick.market_data.types import (
+    CompanyInfo,
+    Fundamentals,
+    MarketNumbers,
+    Quote,
+    TradingStats,
+)
 from maverick.platform.config import DatabaseSettings
 from maverick.platform.db import create_engine_from_settings
 from maverick.portfolio.config import PortfolioSettings
@@ -59,7 +66,7 @@ def _ohlcv_frame(
 
 
 class StubMarketData:
-    """Async fake matching `MarketDataService`'s `get_quote`/`get_price_history` surface."""
+    """Async fake matching the `MarketDataService` surface used by portfolios."""
 
     def __init__(
         self,
@@ -67,13 +74,18 @@ class StubMarketData:
         frames: dict[str, pd.DataFrame] | None = None,
         quote_errors: set[str] | None = None,
         history_errors: set[str] | None = None,
+        sectors: dict[str, str | None] | None = None,
+        fundamentals_errors: set[str] | None = None,
     ) -> None:
         self._quotes = quotes or {}
         self._frames = frames or {}
         self._quote_errors = quote_errors or set()
         self._history_errors = history_errors or set()
+        self._sectors = sectors or {}
+        self._fundamentals_errors = fundamentals_errors or set()
         self.quote_calls: list[str] = []
         self.history_calls: list[tuple[str, date | None, date | None]] = []
+        self.fundamentals_calls: list[str] = []
 
     async def get_quote(self, symbol: str) -> Quote:
         self.quote_calls.append(symbol)
@@ -86,6 +98,37 @@ class StubMarketData:
             change_percent=0.0,
             volume=1_000_000,
             timestamp="2026-07-19T00:00:00+00:00",
+        )
+
+    async def get_fundamentals(self, symbol: str) -> Fundamentals:
+        self.fundamentals_calls.append(symbol)
+        if symbol in self._fundamentals_errors:
+            raise RuntimeError(f"fundamentals fetch failed for {symbol}")
+        return Fundamentals(
+            symbol=symbol,
+            company=CompanyInfo(
+                name=None,
+                sector=self._sectors.get(symbol),
+                industry=None,
+                website=None,
+                description=None,
+            ),
+            market_data=MarketNumbers(
+                current_price=None,
+                market_cap=None,
+                enterprise_value=None,
+                shares_outstanding=None,
+                float_shares=None,
+            ),
+            valuation={},
+            financials={},
+            trading=TradingStats(
+                avg_volume=None,
+                avg_volume_10d=None,
+                beta=None,
+                week_52_high=None,
+                week_52_low=None,
+            ),
         )
 
     async def get_price_history(
@@ -131,6 +174,52 @@ async def test_add_position_creates_new_position(tmp_path):
     assert position.notes == "note"
 
 
+async def test_add_position_stores_looked_up_sector(tmp_path):
+    market_data = StubMarketData(
+        quotes={"AAPL": 150.0}, sectors={"AAPL": "  Technology  "}
+    )
+    service = _service(tmp_path, market_data=market_data)
+
+    await service.add_position(
+        "default", "My Portfolio", "aapl", Decimal("10"), Decimal("100")
+    )
+    snapshot = await service.get_portfolio("default", "My Portfolio")
+
+    assert snapshot.positions[0].sector == "Technology"
+    assert market_data.fundamentals_calls == ["AAPL"]
+
+
+async def test_add_position_fundamentals_failure_stores_null_sector(tmp_path, caplog):
+    market_data = StubMarketData(quotes={"AAPL": 150.0}, fundamentals_errors={"AAPL"})
+    service = _service(tmp_path, market_data=market_data)
+
+    with caplog.at_level(logging.WARNING):
+        position = await service.add_position(
+            "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100")
+        )
+    snapshot = await service.get_portfolio("default", "My Portfolio")
+
+    assert position.sector is None
+    assert snapshot.positions[0].sector is None
+    assert any(
+        "failed to fetch sector for AAPL, storing None" in message
+        for message in caplog.messages
+    )
+
+
+async def test_add_position_empty_sector_stores_null(tmp_path):
+    market_data = StubMarketData(quotes={"AAPL": 150.0}, sectors={"AAPL": ""})
+    service = _service(tmp_path, market_data=market_data)
+
+    position = await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100")
+    )
+    snapshot = await service.get_portfolio("default", "My Portfolio")
+
+    assert position.sector is None
+    assert snapshot.positions[0].sector is None
+
+
 async def test_add_position_second_lot_averages_cost_basis_via_ledger(tmp_path):
     service = _service(tmp_path)
     await service.add_position(
@@ -144,6 +233,42 @@ async def test_add_position_second_lot_averages_cost_basis_via_ledger(tmp_path):
     assert position.shares == Decimal("20")
     assert position.total_cost == Decimal("2200")
     assert position.average_cost_basis == Decimal("110.0000")
+
+
+async def test_add_position_existing_sector_skips_second_fundamentals_lookup(tmp_path):
+    market_data = StubMarketData(sectors={"AAPL": "Technology"})
+    service = _service(tmp_path, market_data=market_data)
+    await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100")
+    )
+    market_data.fundamentals_calls.clear()
+
+    position = await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("120")
+    )
+
+    assert market_data.fundamentals_calls == []
+    assert position.sector == "Technology"
+
+
+async def test_add_position_null_sector_fetches_and_backfills_on_second_lot(tmp_path):
+    sectors: dict[str, str | None] = {"AAPL": None}
+    market_data = StubMarketData(quotes={"AAPL": 150.0}, sectors=sectors)
+    service = _service(tmp_path, market_data=market_data)
+    await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100")
+    )
+    sectors["AAPL"] = "Technology"
+    market_data.fundamentals_calls.clear()
+
+    position = await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("120")
+    )
+    snapshot = await service.get_portfolio("default", "My Portfolio")
+
+    assert market_data.fundamentals_calls == ["AAPL"]
+    assert position.sector == "Technology"
+    assert snapshot.positions[0].sector == "Technology"
 
 
 async def test_add_position_second_lot_with_naive_date_against_stored_aware_date(
@@ -306,6 +431,7 @@ async def test_get_portfolio_empty_returns_zero_metrics(tmp_path):
     assert snapshot.positions == []
     assert snapshot.metrics.position_count == 0
     assert snapshot.metrics.total_invested == Decimal("0")
+    assert snapshot.sector_exposure == {}
 
 
 async def test_get_portfolio_failed_quote_leaves_price_fields_none_but_metrics_fallback(
@@ -343,6 +469,47 @@ async def test_get_portfolio_failed_quote_leaves_price_fields_none_but_metrics_f
     assert snapshot.metrics.total_pnl_percent == 25.0
     assert snapshot.metrics.position_count == 2
     assert set(market_data.quote_calls) == {"AAPL", "MSFT"}
+
+
+async def test_get_portfolio_sector_exposure_uses_quote_fallback_and_unknown_bucket(
+    tmp_path,
+):
+    market_data = StubMarketData(
+        quotes={"AAPL": 150.0},
+        quote_errors={"MSFT"},
+        sectors={"AAPL": "Technology", "MSFT": None},
+    )
+    service = _service(tmp_path, market_data=market_data)
+    await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100")
+    )
+    await service.add_position(
+        "default", "My Portfolio", "MSFT", Decimal("5"), Decimal("200")
+    )
+
+    snapshot = await service.get_portfolio("default", "My Portfolio")
+
+    assert snapshot.sector_exposure == {"Technology": 0.6, "Unknown": 0.4}
+    assert sum(snapshot.sector_exposure.values()) == pytest.approx(1.0)
+
+
+async def test_get_portfolio_sector_exposure_uses_unrounded_position_values(tmp_path):
+    market_data = StubMarketData(
+        quotes={"AAPL": 1.004, "MSFT": 2.004},
+        sectors={"AAPL": "Technology", "MSFT": "Industrials"},
+    )
+    service = _service(tmp_path, market_data=market_data)
+    await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("1"), Decimal("1")
+    )
+    await service.add_position(
+        "default", "My Portfolio", "MSFT", Decimal("1"), Decimal("2")
+    )
+
+    snapshot = await service.get_portfolio("default", "My Portfolio")
+
+    assert snapshot.sector_exposure == {"Technology": 0.3338, "Industrials": 0.6662}
+    assert sum(snapshot.sector_exposure.values()) == pytest.approx(1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -631,7 +798,10 @@ def _spy_frame(n: int = 60, start: float = 100.0) -> pd.DataFrame:
 
 
 async def test_get_risk_dashboard_seeded_positions_via_service_reads(tmp_path):
-    market_data = StubMarketData(quotes={"AAPL": 150.0, "MSFT": 100.0})
+    market_data = StubMarketData(
+        quotes={"AAPL": 150.0, "MSFT": 100.0},
+        sectors={"AAPL": "Technology", "MSFT": None},
+    )
     service = _service(tmp_path, market_data=market_data)
     await service.add_position(
         "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100"), "2026-01-01"
@@ -642,9 +812,9 @@ async def test_get_risk_dashboard_seeded_positions_via_service_reads(tmp_path):
 
     result = await service.get_risk_dashboard("default", "My Portfolio")
 
-    # value = 10*150 + 10*100 = 2500; sector "Unknown" 100% concentrated.
+    # value = 10*150 + 10*100 = 2500; Technology = 60%, Unknown = 40%.
     assert result.total_value == 2500.0
-    assert result.sector_concentration == {"Unknown": 1.0}
+    assert result.sector_concentration == {"Technology": 0.6, "Unknown": 0.4}
     assert result.position_count == 2
     assert set(market_data.quote_calls) == {"AAPL", "MSFT"}
 
@@ -687,6 +857,51 @@ async def test_check_position_risk_projects_against_seeded_holdings(tmp_path):
     assert result.current.total_value == 1500.0
     assert result.projected.total_value == 1500.0 + 2000.0
     assert result.new_position.ticker == "MSFT"
+
+
+async def test_check_position_risk_new_ticker_uses_looked_up_sector(tmp_path):
+    market_data = StubMarketData(sectors={"MSFT": "Technology"})
+    service = _service(tmp_path, market_data=market_data)
+
+    result = await service.check_position_risk(
+        "default", "My Portfolio", "MSFT", 10, 200.0
+    )
+
+    assert result.projected.sector_concentration == {"Technology": 1.0}
+
+
+async def test_check_position_risk_held_ticker_reuses_sector_without_lookup(tmp_path):
+    market_data = StubMarketData(quotes={"AAPL": 150.0}, sectors={"AAPL": "Technology"})
+    service = _service(tmp_path, market_data=market_data)
+    await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100")
+    )
+    market_data.fundamentals_calls.clear()
+
+    result = await service.check_position_risk(
+        "default", "My Portfolio", "AAPL", 5, 160.0
+    )
+
+    assert market_data.fundamentals_calls == []
+    assert result.projected.sector_concentration == {"Technology": 1.0}
+
+
+async def test_check_position_risk_held_null_sector_uses_fresh_lookup(tmp_path):
+    sectors: dict[str, str | None] = {"AAPL": None}
+    market_data = StubMarketData(quotes={"AAPL": 150.0}, sectors=sectors)
+    service = _service(tmp_path, market_data=market_data)
+    await service.add_position(
+        "default", "My Portfolio", "AAPL", Decimal("10"), Decimal("100")
+    )
+    sectors["AAPL"] = "Technology"
+    market_data.fundamentals_calls.clear()
+
+    result = await service.check_position_risk(
+        "default", "My Portfolio", "AAPL", 5, 160.0
+    )
+
+    assert market_data.fundamentals_calls == ["AAPL"]
+    assert result.projected.sector_concentration == {"Technology": 1.0}
 
 
 async def test_check_position_risk_rejects_invalid_ticker(tmp_path):

--- a/tests/portfolio/test_tools.py
+++ b/tests/portfolio/test_tools.py
@@ -65,6 +65,7 @@ def _snapshot() -> PortfolioSnapshot:
         name="My Portfolio",
         positions=[position],
         metrics=metrics,
+        sector_exposure={"Unknown": 1.0},
         as_of="2026-07-19T00:00:00+00:00",
     )
 

--- a/tests/portfolio/test_types.py
+++ b/tests/portfolio/test_types.py
@@ -234,6 +234,7 @@ def test_portfolio_snapshot_composes_positions_and_metrics():
         name="My Portfolio",
         positions=[position],
         metrics=metrics,
+        sector_exposure={"Technology": 1.0},
         as_of="2026-07-19T00:00:00+00:00",
     )
     assert snapshot.user_id == "default"
@@ -242,6 +243,7 @@ def test_portfolio_snapshot_composes_positions_and_metrics():
     assert snapshot.positions[0].shares == Decimal("10.0001")
     assert snapshot.metrics == metrics
     assert snapshot.metrics.total_invested == Decimal("1502.75")
+    assert snapshot.sector_exposure == {"Technology": 1.0}
     assert snapshot.as_of == "2026-07-19T00:00:00+00:00"
 
 
@@ -258,6 +260,7 @@ def test_portfolio_snapshot_allows_empty_positions():
         name="My Portfolio",
         positions=[],
         metrics=metrics,
+        sector_exposure={},
         as_of="2026-07-19T00:00:00+00:00",
     )
     assert snapshot.positions == []
@@ -288,6 +291,7 @@ def test_portfolio_snapshot_round_trips_through_model_dump():
         name="My Portfolio",
         positions=[position],
         metrics=metrics,
+        sector_exposure={"Technology": 1.0},
         as_of="2026-07-19T00:00:00+00:00",
     )
     data = snapshot.model_dump()
@@ -318,6 +322,7 @@ def test_portfolio_snapshot_model_dump_json_mode_serializes_nested_decimal_as_st
         name="My Portfolio",
         positions=[position_with_price],
         metrics=metrics,
+        sector_exposure={"Unknown": 1.0},
         as_of="2026-07-19T00:00:00+00:00",
     )
     json_data = snapshot.model_dump(mode="json")


### PR DESCRIPTION
Implements #189.

- `sector` column (nullable) on `pf_positions`; existing DBs migrate automatically at startup (`ensure_schema` now adds missing plain nullable columns, warns on skipped constrained/non-nullable ones, tolerates concurrent-migration races)
- `portfolio_add_position` auto-populates the sector from yfinance fundamentals, best-effort: provider failure stores NULL and never blocks the write; averaging into a tagged position skips the (uncached) fetch; NULL-sector positions backfill on the next lot
- Risk exposures use the stored sector; the pre-trade `portfolio_check_position_risk` projection resolves the candidate ticker's real sector instead of hardcoding Unknown
- New `sector_exposure` fractions on the portfolio snapshot (cost-basis fallback for failed quotes, single-pass with metrics)
- The spurious "Sector 'Unknown' represents 100.0%" critical alert on every portfolio is gone: Unknown stays visible in concentration but never alerts
- Docs: Sector Tagging section in `docs/features/portfolio.md`

Verification: 1132 passed (`-m 'not integration and not slow and not external'`), `make lint` (14 contracts kept), `make docs-check` green; pyright error count identical to main.

Closes #189