### PR TITLE
build: scope ruff formatter to Python so ruff 0.16 can land

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,10 @@ ignore = [
 "tests/*" = ["F403", "F405"]  # star imports allowed in tests
 
 [tool.ruff.format]
+# Ruff 0.16 stabilized Markdown code-block formatting, which was preview-gated
+# in 0.15. Keep the formatter scoped to Python so prose docs — including the
+# archived exec-plans under docs/ — keep their snippets as authored.
+exclude = ["*.md"]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false


### PR DESCRIPTION
## Summary

Unblocks #226 (`chore(deps): bump ruff from 0.15.14 to 0.16.3`), which currently fails `Lint (ruff)`.

**Root cause:** Ruff 0.16 stabilized Markdown code-block formatting, which was preview-gated in 0.15. Same file, two versions:

```
0.15.14 -> error: Markdown formatting is experimental, enable preview mode.
0.16.3  -> 1 file would be reformatted
```

With the gate lifted the formatter picks up 73 more files and flags 7 Markdown docs, so `ruff format --check .` exits 1. **No Python file is affected**, and `ruff check .` passes clean on 0.16.3.

The 7 files are:

- `conductor/code_styleguides/python.md`
- `docs/api/backtesting.md`
- `docs/exec-plans/completed/2026-07-18-phase-0-harness-and-cleanup.md`
- `docs/exec-plans/completed/2026-07-18-phase-1-platform-seam.md`
- `docs/exec-plans/completed/2026-07-19-phase-2-market-data-domain.md`
- `docs/superpowers/plans/2026-03-27-maverick-roadmap-v1.md`
- `docs/superpowers/specs/2026-03-27-maverick-roadmap-v1-design.md`

Five are historical records (completed exec-plans, superpowers specs). Reformatting would rewrite archived documents for a purely cosmetic gain: the changes explode hugging-brace calls onto separate lines across 569 diff lines, which reads worse in prose docs. So this scopes the formatter to Python rather than accepting the churn.

The alternative, if you prefer formatting the docs, is `ruff format .` once #226 lands. This PR is the lower-churn option.

## Test plan

Verified under both the currently pinned ruff and the version #226 moves to:

| ruff | `ruff check .` | `ruff format --check .` |
|---|---|---|
| 0.15.14 (current pin) | All checks passed | 190 files already formatted |
| 0.16.3 (post-#226) | All checks passed | 190 files already formatted |

`exclude` under `[tool.ruff.format]` is accepted by 0.15.14, so this is safe to merge before #226.

- [x] `lint-imports` : 14 contracts kept, 0 broken
- [x] `uv lock --check` : lockfile still valid (CI syncs `--frozen`)
- [x] `make docs-check` : 73 tracked docs pass
- [x] Config-only change; no runtime code touched
