### PR TITLE
fix(research): migrate Exa provider off deprecated search_and_contents

### DIFF
--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -20,4 +20,3 @@ One line per item. Remove the line in the same change that removes the debt.
 | run_screen executes rubrics on the event loop; wrap in to_thread if universe_max grows | `maverick/screening/service.py` | deferred |
 | `pf_positions.total_cost` Numeric(20,4) would round >4dp fractional-share totals on Postgres (SQLite unaffected); revisit if Postgres adopted | `maverick/portfolio/data.py` | deferred |
 | service_ml.py, ensemble.py, online_learning.py, and feature_engineering.py at 499-500/500 line cap; split before next addition | `maverick/backtesting/service_ml.py`, `maverick/backtesting/strategies/ml/ensemble.py`, `maverick/backtesting/strategies/ml/online_learning.py`, `maverick/backtesting/strategies/ml/feature_engineering.py` | deferred |
-| exa search_and_contents() deprecated upstream -- migrate to search() post-cutover | `maverick/research/providers/exa.py` | deferred |

--- a/maverick/research/providers/exa.py
+++ b/maverick/research/providers/exa.py
@@ -250,9 +250,7 @@ class ExaSearchProvider(WebSearchProvider):
             try:
                 async_exa_client = AsyncExa(api_key=self.api_key)
                 search_params = self._get_search_params(query, num_results, strategy)
-                exa_response = await async_exa_client.search_and_contents(
-                    **search_params
-                )
+                exa_response = await async_exa_client.search(**search_params)
             except Exception as e:
                 logger.error(f"Error calling Exa API: {e}")
                 raise
@@ -291,7 +289,7 @@ class ExaSearchProvider(WebSearchProvider):
             raise WebSearchError(f"Exa search failed: {str(e)}") from e
 
     def _normalize_response(self, exa_response: Any) -> list[dict[str, Any]]:
-        """Convert an Exa `search_and_contents` response into the legacy result shape."""
+        """Convert an Exa `search` response into the legacy result shape."""
         results = []
         if exa_response and hasattr(exa_response, "results"):
             for result in exa_response.results:
@@ -328,7 +326,7 @@ class ExaSearchProvider(WebSearchProvider):
         params: dict[str, Any] = {
             "query": query,
             "num_results": num_results,
-            "text": {"max_characters": 5000},
+            "contents": {"text": {"max_characters": 5000}},
         }
 
         if strategy == "authoritative":

--- a/tests/research/test_providers.py
+++ b/tests/research/test_providers.py
@@ -120,6 +120,29 @@ async def test_search_raises_when_exa_py_is_not_installed(
 # ---------------------------------------------------------------------------
 
 
+async def test_search_passes_content_options_nested_under_contents():
+    """`search()` takes content options under `contents`; the deprecated
+    `search_and_contents()` nested them on the caller's behalf. Nothing else
+    guards the shape -- `search_params` is a `dict[str, Any]` splatted into the
+    call, so a revert to a top-level `text=` kwarg type-checks fine and only
+    fails against the live API. Pin it here.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_search(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _Response([_result()])
+
+    provider = ExaSearchProvider("test-key")
+    with pytest.MonkeyPatch.context() as mp:
+        _install_fake_exa_py(mp, fake_search)
+        await provider.search("AAPL earnings", num_results=5)
+
+    assert captured["contents"] == {"text": {"max_characters": 5000}}
+    assert "text" not in captured
+    assert captured["num_results"] == 5
+
+
 async def test_search_normalizes_fields():
     results_in = [
         _result(

--- a/tests/research/test_providers.py
+++ b/tests/research/test_providers.py
@@ -26,10 +26,10 @@ from maverick.research.providers.exa import ExaSearchProvider
 
 def _install_fake_exa_py(
     monkeypatch: pytest.MonkeyPatch,
-    search_and_contents: Callable[..., Awaitable[Any]],
+    search_impl: Callable[..., Awaitable[Any]],
 ) -> None:
-    """Install a fake `exa_py` module: `AsyncExa(api_key).search_and_contents(**kw)`
-    delegates to `search_and_contents`. Mirrors legacy's own import seam
+    """Install a fake `exa_py` module: `AsyncExa(api_key).search(**kw)`
+    delegates to `search_impl`. Mirrors legacy's own import seam
     (`from exa_py import AsyncExa` inside the search call), so
     `ExaSearchProvider` needs no code changes to be testable this way.
     """
@@ -39,8 +39,8 @@ def _install_fake_exa_py(
         def __init__(self, api_key: str) -> None:
             self.api_key = api_key
 
-        async def search_and_contents(self, **kwargs: Any) -> Any:
-            return await search_and_contents(**kwargs)
+        async def search(self, **kwargs: Any) -> Any:
+            return await search_impl(**kwargs)
 
     fake_module.AsyncExa = FakeAsyncExa  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "exa_py", fake_module)
@@ -132,12 +132,12 @@ async def test_search_normalizes_fields():
         )
     ]
 
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         return _Response(results_in)
 
     provider = ExaSearchProvider("test-key")
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
         results = await provider.search("AAPL earnings", num_results=5)
 
     assert len(results) == 1
@@ -156,12 +156,12 @@ async def test_search_normalizes_fields():
 
 
 async def test_search_defaults_missing_score_and_author():
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         return _Response([_result(url="https://example.com", title=None, text=None)])
 
     provider = ExaSearchProvider("test-key")
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
         results = await provider.search("widget prices")
 
     item = results[0]
@@ -189,12 +189,12 @@ async def test_search_truncation_boundaries(
 ):
     text = "x" * text_len
 
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         return _Response([_result(text=text)])
 
     provider = ExaSearchProvider("test-key")
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
         results = await provider.search("query")
 
     item = results[0]
@@ -210,12 +210,12 @@ async def test_search_sorts_by_financial_relevance_then_score():
         score=0.1,
     )
 
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         return _Response([low, high])
 
     provider = ExaSearchProvider("test-key")
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
         results = await provider.search("query")
 
     assert [r["url"] for r in results] == [
@@ -230,12 +230,12 @@ async def test_search_sorts_by_financial_relevance_then_score():
 
 
 async def test_search_wraps_client_error_in_web_search_error():
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         raise RuntimeError("boom")
 
     provider = ExaSearchProvider("test-key")
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
         with pytest.raises(WebSearchError, match="Exa search failed"):
             await provider.search("query")
 
@@ -246,14 +246,14 @@ async def test_search_wraps_client_error_in_web_search_error():
 async def test_provider_disables_itself_after_repeated_non_timeout_failures():
     call_count = 0
 
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         nonlocal call_count
         call_count += 1
         raise RuntimeError("boom")
 
     provider = ExaSearchProvider("test-key")
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
 
         for _ in range(6):  # _MAX_NON_TIMEOUT_FAILURES
             with pytest.raises(WebSearchError):
@@ -271,7 +271,7 @@ async def test_provider_disables_itself_after_repeated_non_timeout_failures():
 async def test_successful_search_resets_failure_count():
     calls: list[bool] = []
 
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         if not calls:
             calls.append(True)
             raise RuntimeError("boom")
@@ -279,7 +279,7 @@ async def test_successful_search_resets_failure_count():
 
     provider = ExaSearchProvider("test-key")
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
 
         with pytest.raises(WebSearchError):
             await provider.search("query")
@@ -296,7 +296,7 @@ async def test_successful_search_resets_failure_count():
 
 
 async def test_open_circuit_breaker_short_circuits_subsequent_calls():
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         raise RuntimeError("boom")
 
     # A single failure trips the breaker; recovery is set far in the
@@ -308,7 +308,7 @@ async def test_open_circuit_breaker_short_circuits_subsequent_calls():
     provider = ExaSearchProvider("test-key", settings=settings)
 
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
 
         with pytest.raises(WebSearchError, match="Exa search failed"):
             await provider.search("first query")
@@ -331,7 +331,7 @@ async def test_open_circuit_breaker_short_circuits_subsequent_calls():
 async def test_search_timeout_raises_web_search_error():
     import asyncio
 
-    async def fake_search_and_contents(**kwargs: Any) -> Any:
+    async def fake_search(**kwargs: Any) -> Any:
         await asyncio.sleep(10)
         return _Response([])
 
@@ -340,7 +340,7 @@ async def test_search_timeout_raises_web_search_error():
     provider._calculate_timeout = lambda *args, **kwargs: 0.01  # type: ignore[method-assign]
 
     with pytest.MonkeyPatch.context() as mp:
-        _install_fake_exa_py(mp, fake_search_and_contents)
+        _install_fake_exa_py(mp, fake_search)
         with pytest.raises(WebSearchError, match="timed out"):
             await provider.search("query")
 


### PR DESCRIPTION
## Summary

Unblocks #228 (`chore(deps): bump ty from 0.0.43 to 0.0.71`) and retires a tracked debt item.

**#228 does not introduce a new diagnostic.** `ty` already reports this on `main` today; it just does not fail the build. Same tree, two versions:

```
ty 0.0.43 -> warning[deprecated]: search_and_contents ... exit=0
ty 0.0.71 -> warning[deprecated]: search_and_contents ... exit=1
```

The CI logs on the currently *passing* dependency PRs print `Found 1 diagnostic` while reporting SUCCESS. 0.0.71 changes the exit-code policy for warnings, which surfaces the real debt below.

`docs/exec-plans/tech-debt-tracker.md` already tracked it as deferred:

> exa search_and_contents() deprecated upstream -- migrate to search() post-cutover

The tracker says to remove the line in the same change that removes the debt, so this PR does.

## The change is not a rename

exa-py 2.13.0 marks `AsyncExa.search_and_contents` with `typing_extensions.deprecated`. Before hitting `/search`, that method nested content fields under `contents` on the caller's behalf:

```python
options = nest_fields(options, ["text", "summary", "highlights", ...], "contents")
```

`search()` takes `contents` directly, so passing `text=` straight through would send it as a top-level key. `_get_search_params` now nests it:

```python
"text": {"max_characters": 5000},   ->   "contents": {"text": {"max_characters": 5000}},
```

Every other key the provider builds (`num_results`, `include_domains`, `exclude_domains`, `type`, `start_published_date`) is already keyword-only on `search()`, so it passes through unchanged.

**Behavior is unchanged.** `search()` defaults contents to text at 10,000 max characters; the provider keeps passing an explicit 5,000.

The test seam stubs the client method rather than asserting on params, so the fake's method is renamed to match. Its callable parameter becomes `search_impl` so it does not shadow the method name.

## Test plan

- [x] `ty check maverick` clean on **0.0.43** (current pin) and **0.0.71** (post-#228), both exit 0 - was `Found 1 diagnostic` before
- [x] `pytest -m "not integration and not slow and not external"` : **1132 passed**
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `lint-imports` : 14 contracts kept, 0 broken
- [x] `make docs-check` : 73 tracked docs pass
- [x] No `search_and_contents` references remain anywhere in the repo
