### PR TITLE
fix(backtesting): report worst portfolio drawdown

### DIFF
--- a/docs/api/backtesting.md
+++ b/docs/api/backtesting.md
@@ -321,7 +321,11 @@ Backtest multiple strategies on the same symbol and rank them.
 
 Backtest one strategy across multiple symbols and aggregate portfolio-level
 metrics. Per-symbol backtests run with bounded concurrency (a semaphore of
-6, matching the legacy effective parallelism).
+6, matching the legacy effective parallelism). Each symbol is backtested
+independently -- there is no combined equity curve and no cross-symbol
+correlation. `total_return`/`average_sharpe` are per-symbol averages;
+`max_drawdown` is the worst (most negative) constituent drawdown, not a
+joint-portfolio calculation.
 
 **Tool name**: `backtesting_backtest_portfolio` (readOnlyHint: true)
 

--- a/maverick/backtesting/service.py
+++ b/maverick/backtesting/service.py
@@ -355,9 +355,10 @@ class BacktestingService(_ExtendedBacktestingMixin):
 
             total_return = sum(r.metrics.total_return for r in results) / len(results)
             average_sharpe = sum(r.metrics.sharpe_ratio for r in results) / len(results)
-            # `BacktestMetrics.max_drawdown` is signed (0 or negative); the worst constituent
-            # drawdown is the most negative value, i.e. `min()`, not `max()`. `max()` selected
-            # the mildest constituent instead of the worst, understating portfolio-level risk.
+            # `BacktestMetrics.max_drawdown` is signed (0 or negative); the worst
+            # constituent drawdown is the most negative value, i.e. `min()`, not
+            # `max()`. `max()` selected the mildest constituent instead of the
+            # worst, understating portfolio-level risk.
             max_drawdown = min(r.metrics.max_drawdown for r in results)
             total_trades = sum(r.metrics.total_trades for r in results)
 

--- a/maverick/backtesting/service.py
+++ b/maverick/backtesting/service.py
@@ -355,7 +355,10 @@ class BacktestingService(_ExtendedBacktestingMixin):
 
             total_return = sum(r.metrics.total_return for r in results) / len(results)
             average_sharpe = sum(r.metrics.sharpe_ratio for r in results) / len(results)
-            max_drawdown = max(r.metrics.max_drawdown for r in results)
+            # `BacktestMetrics.max_drawdown` is signed (0 or negative); the worst constituent
+            # drawdown is the most negative value, i.e. `min()`, not `max()`. `max()` selected
+            # the mildest constituent instead of the worst, understating portfolio-level risk.
+            max_drawdown = min(r.metrics.max_drawdown for r in results)
             total_trades = sum(r.metrics.total_trades for r in results)
 
             return PortfolioBacktestResult(

--- a/maverick/backtesting/tools.py
+++ b/maverick/backtesting/tools.py
@@ -232,7 +232,11 @@ async def backtesting_backtest_portfolio(
     slow_period: int | None = None,
     period: int | None = None,
 ) -> dict[str, Any]:
-    """Backtest one strategy across multiple symbols and aggregate portfolio-level metrics."""
+    """Backtest one strategy across multiple symbols and aggregate portfolio-level metrics.
+
+    Each symbol is backtested independently (no combined equity curve, no cross-symbol
+    correlation). `total_return`/`average_sharpe` are per-symbol averages; `max_drawdown` is
+    the worst (most negative) constituent drawdown, not a joint-portfolio calculation."""
     try:
         service = _require_service()
         result = await service.backtest_portfolio(

--- a/maverick/backtesting/tools.py
+++ b/maverick/backtesting/tools.py
@@ -232,11 +232,13 @@ async def backtesting_backtest_portfolio(
     slow_period: int | None = None,
     period: int | None = None,
 ) -> dict[str, Any]:
-    """Backtest one strategy across multiple symbols and aggregate portfolio-level metrics.
+    """Backtest one strategy across multiple symbols and aggregate portfolio-level
+    metrics.
 
-    Each symbol is backtested independently (no combined equity curve, no cross-symbol
-    correlation). `total_return`/`average_sharpe` are per-symbol averages; `max_drawdown` is
-    the worst (most negative) constituent drawdown, not a joint-portfolio calculation."""
+    Each symbol is backtested independently (no combined equity curve, no
+    cross-symbol correlation). `total_return`/`average_sharpe` are per-symbol
+    averages; `max_drawdown` is the worst (most negative) constituent
+    drawdown, not a joint-portfolio calculation."""
     try:
         service = _require_service()
         result = await service.backtest_portfolio(

--- a/maverick/backtesting/types.py
+++ b/maverick/backtesting/types.py
@@ -296,10 +296,11 @@ class StrategyCatalog(BaseModel):
 
 
 class PortfolioBacktestMetrics(BaseModel):
-    """Aggregated across each symbol's independent single-symbol backtest -- not a joint
-    portfolio-equity simulation (no combined equity curve, no correlation between symbols).
-    `total_return`/`average_sharpe` are plain per-symbol averages; `max_drawdown` is the worst
-    (most negative) constituent drawdown, matching `BacktestMetrics.max_drawdown`'s sign
+    """Aggregated across each symbol's independent single-symbol backtest -- not
+    a joint portfolio-equity simulation (no combined equity curve, no
+    correlation between symbols). `total_return`/`average_sharpe` are plain
+    per-symbol averages; `max_drawdown` is the worst (most negative)
+    constituent drawdown, matching `BacktestMetrics.max_drawdown`'s sign
     convention (0 or negative, more negative is worse)."""
 
     symbols_tested: int

--- a/maverick/backtesting/types.py
+++ b/maverick/backtesting/types.py
@@ -296,6 +296,12 @@ class StrategyCatalog(BaseModel):
 
 
 class PortfolioBacktestMetrics(BaseModel):
+    """Aggregated across each symbol's independent single-symbol backtest -- not a joint
+    portfolio-equity simulation (no combined equity curve, no correlation between symbols).
+    `total_return`/`average_sharpe` are plain per-symbol averages; `max_drawdown` is the worst
+    (most negative) constituent drawdown, matching `BacktestMetrics.max_drawdown`'s sign
+    convention (0 or negative, more negative is worse)."""
+
     symbols_tested: int
     total_return: float
     average_sharpe: float

--- a/tests/backtesting/test_service.py
+++ b/tests/backtesting/test_service.py
@@ -17,6 +17,8 @@ pytest.importorskip("sklearn")
 from maverick.backtesting.config import BacktestingSettings
 from maverick.backtesting.service import BacktestingService
 from maverick.backtesting.types import (
+    BacktestMetrics,
+    BacktestResult,
     EnsembleBacktestResult,
     MarketRegimeAnalysis,
     MLBacktestResult,
@@ -258,6 +260,94 @@ async def test_backtest_portfolio_raises_when_every_symbol_fails():
 
     with pytest.raises(ValueError, match="No symbols could be backtested"):
         await service.backtest_portfolio(["AAPL", "MSFT"])
+
+
+def _canned_backtest_result(symbol: str, max_drawdown: float) -> BacktestResult:
+    """Minimal `BacktestResult` with a controlled `metrics.max_drawdown`, for aggregation
+    tests that don't need a real vectorbt-driven backtest to produce a specific drawdown."""
+    return BacktestResult(
+        symbol=symbol,
+        strategy="sma_cross",
+        parameters={},
+        metrics=BacktestMetrics(
+            total_return=0.0,
+            annual_return=0.0,
+            sharpe_ratio=0.0,
+            sortino_ratio=0.0,
+            calmar_ratio=0.0,
+            max_drawdown=max_drawdown,
+            win_rate=0.0,
+            profit_factor=0.0,
+            expectancy=0.0,
+            total_trades=0,
+            winning_trades=0,
+            losing_trades=0,
+            avg_win=0.0,
+            avg_loss=0.0,
+            best_trade=0.0,
+            worst_trade=0.0,
+            avg_duration=0.0,
+            kelly_criterion=0.0,
+            recovery_factor=0.0,
+            risk_reward_ratio=0.0,
+        ),
+        trades=[],
+        equity_curve={},
+        drawdown_series={},
+        start_date="2022-01-01",
+        end_date="2022-12-31",
+        initial_capital=1000.0,
+    )
+
+
+def _stub_per_symbol_drawdowns(
+    service: BacktestingService, drawdowns: dict[str, float]
+) -> None:
+    """Monkeypatch `_run_single_backtest` to return a canned result per symbol, isolating
+    `backtest_portfolio`'s aggregation from vectorbt/signal-generation entirely."""
+
+    async def _fake(symbol, strategy, start, end, *, initial_capital, parameters=None):
+        return _canned_backtest_result(symbol, drawdowns[symbol])
+
+    service._run_single_backtest = _fake  # type: ignore[method-assign]
+
+
+async def test_backtest_portfolio_max_drawdown_selects_worst_not_mildest():
+    """Regression test for the `max()`-on-signed-values bug: a portfolio containing a mild
+    -12.4% drawdown and a severe -21.3% drawdown must report the severe one, not the mild
+    one."""
+    service = _service(StubMarketData(pd.DataFrame()))
+    _stub_per_symbol_drawdowns(service, {"AAPL": -0.124, "MSFT": -0.213})
+
+    result = await service.backtest_portfolio(["AAPL", "MSFT"])
+
+    assert result.portfolio_metrics.max_drawdown == pytest.approx(-0.213)
+
+
+async def test_backtest_portfolio_max_drawdown_is_order_independent():
+    service_a = _service(StubMarketData(pd.DataFrame()))
+    _stub_per_symbol_drawdowns(
+        service_a, {"AAPL": -0.124, "MSFT": -0.213, "JPM": -0.05}
+    )
+    service_b = _service(StubMarketData(pd.DataFrame()))
+    _stub_per_symbol_drawdowns(
+        service_b, {"AAPL": -0.124, "MSFT": -0.213, "JPM": -0.05}
+    )
+
+    result_forward = await service_a.backtest_portfolio(["AAPL", "MSFT", "JPM"])
+    result_reversed = await service_b.backtest_portfolio(["JPM", "MSFT", "AAPL"])
+
+    assert result_forward.portfolio_metrics.max_drawdown == pytest.approx(-0.213)
+    assert result_reversed.portfolio_metrics.max_drawdown == pytest.approx(-0.213)
+
+
+async def test_backtest_portfolio_max_drawdown_zero_when_no_symbol_drew_down():
+    service = _service(StubMarketData(pd.DataFrame()))
+    _stub_per_symbol_drawdowns(service, {"AAPL": 0.0, "MSFT": 0.0})
+
+    result = await service.backtest_portfolio(["AAPL", "MSFT"])
+
+    assert result.portfolio_metrics.max_drawdown == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backtesting/test_service.py
+++ b/tests/backtesting/test_service.py
@@ -263,8 +263,9 @@ async def test_backtest_portfolio_raises_when_every_symbol_fails():
 
 
 def _canned_backtest_result(symbol: str, max_drawdown: float) -> BacktestResult:
-    """Minimal `BacktestResult` with a controlled `metrics.max_drawdown`, for aggregation
-    tests that don't need a real vectorbt-driven backtest to produce a specific drawdown."""
+    """Minimal `BacktestResult` with a controlled `metrics.max_drawdown`, for
+    aggregation tests that don't need a real vectorbt-driven backtest to
+    produce a specific drawdown."""
     return BacktestResult(
         symbol=symbol,
         strategy="sma_cross",
@@ -303,8 +304,9 @@ def _canned_backtest_result(symbol: str, max_drawdown: float) -> BacktestResult:
 def _stub_per_symbol_drawdowns(
     service: BacktestingService, drawdowns: dict[str, float]
 ) -> None:
-    """Monkeypatch `_run_single_backtest` to return a canned result per symbol, isolating
-    `backtest_portfolio`'s aggregation from vectorbt/signal-generation entirely."""
+    """Monkeypatch `_run_single_backtest` to return a canned result per symbol,
+    isolating `backtest_portfolio`'s aggregation from vectorbt/signal-generation
+    entirely."""
 
     async def _fake(symbol, strategy, start, end, *, initial_capital, parameters=None):
         return _canned_backtest_result(symbol, drawdowns[symbol])
@@ -313,9 +315,9 @@ def _stub_per_symbol_drawdowns(
 
 
 async def test_backtest_portfolio_max_drawdown_selects_worst_not_mildest():
-    """Regression test for the `max()`-on-signed-values bug: a portfolio containing a mild
-    -12.4% drawdown and a severe -21.3% drawdown must report the severe one, not the mild
-    one."""
+    """Regression test for the `max()`-on-signed-values bug: a portfolio
+    containing a mild -12.4% drawdown and a severe -21.3% drawdown must report
+    the severe one, not the mild one."""
     service = _service(StubMarketData(pd.DataFrame()))
     _stub_per_symbol_drawdowns(service, {"AAPL": -0.124, "MSFT": -0.213})
 


### PR DESCRIPTION
## 📋 Pull Request Summary

**Brief description of changes:**
Fixes `backtesting_backtest_portfolio`'s portfolio-level `max_drawdown` aggregation, which reported the mildest constituent drawdown instead of the worst one.

**Related issue(s):**
- Fixes #245

## 💰 Financial Disclaimer Acknowledgment

- [x] I understand this is educational software and not financial advice
- [x] Any financial analysis features include appropriate disclaimers
- [x] This PR maintains the educational/personal-use focus of the project

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements to documentation)
- [ ] 🔧 Refactor (code changes that neither fix bugs nor add features)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (dependencies, build tools, etc.)

## 🎯 Component Areas

**Primary areas affected:**
- [ ] Data fetching (Tiingo, Yahoo Finance, FRED)
- [ ] Technical analysis calculations
- [ ] Stock screening strategies
- [ ] Portfolio analysis and optimization
- [x] MCP server/tools implementation (backtesting domain)
- [ ] Database operations and models
- [ ] Caching (Redis/in-memory)
- [ ] Claude Desktop integration
- [ ] Development tools and setup
- [x] Documentation and examples

## 🔧 Implementation Details

**Technical approach:**
`backtesting_backtest_portfolio` aggregates each backtested symbol's `max_drawdown` into a single portfolio-level figure. `BacktestMetrics.max_drawdown` values are signed (0 or negative; more negative is worse), but the aggregation used `max()` over that signed value, which returns the value *closest to zero* -- the mildest constituent drawdown, not the worst one.

**Key changes:**
- Changed the aggregation in `maverick/backtesting/service.py::BacktestingService.backtest_portfolio` from `max()` to `min()` over the same signed values -- the smallest change consistent with the field's existing (unchanged) sign convention and API contract.
- Documented the aggregation semantics (worst constituent, not a joint-portfolio-equity calculation) on `PortfolioBacktestMetrics` and the tool description, since neither stated this previously.

**Dependencies:**
- [x] No new dependencies added

## 🧪 Testing

**Testing performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (live MCP tool call reproducing the exact bug scenario, pre- and post-fix)
- [ ] Tested with Claude Desktop
- [ ] Tested with different data sources
- [ ] Performance testing completed

**Test scenarios covered:**
- [x] Happy path functionality
- [x] Error handling and edge cases (zero-drawdown case; symbol-order independence)
- [ ] Data validation and sanitization
- [ ] API rate limiting compliance
- [ ] Database operations
- [ ] Cache behavior

**Manual testing:**
```bash
uv run pytest tests/backtesting/ tests/server/
uv run --extra dev ruff check .
uv run --extra dev ruff format --check .
uv run lint-imports
```
Result: 243 passed, 5 skipped (pre-existing, Research-extra-gated), 0 failed. `lint-imports`: 14/14 contracts kept. `ruff check`/`ruff format --check`: clean.

`make typecheck` could not be verified in this environment: it requires `--extra research` to resolve `maverick.backtesting.strategies.parser`'s lazy BYOK-LLM import (a pre-existing condition unrelated to this PR -- `parser.py` is untouched by this diff), and this environment does not install the `[research]` extra. Not claiming this check as passed.

## 📊 Financial Analysis Impact

**Financial calculations:**
- [ ] No financial calculations affected
- [ ] New financial calculations added (validated for accuracy)
- [x] Existing calculations modified (thoroughly tested)
- [x] All calculations include appropriate disclaimers

**Data providers:**
- [x] No data provider changes

**Market data handling:**
- [ ] Historical data processing
- [ ] Real-time data integration
- [ ] Technical indicator calculations
- [ ] Screening algorithm changes

## 🔒 Security Considerations

**Security checklist:**
- [x] No hardcoded secrets or credentials
- [x] Input validation implemented (unchanged; not affected by this fix)
- [x] Error handling doesn't leak sensitive information
- [x] API keys handled securely via environment variables (unaffected)
- [x] SQL injection prevention verified (not applicable -- no SQL in this path)
- [x] Rate limiting respected for external APIs (unaffected)

## 📚 Documentation

**Documentation updates:**
- [x] Code comments added/updated
- [ ] README.md updated (if needed)
- [x] API documentation updated (`docs/api/backtesting.md`)
- [ ] Examples/tutorials added
- [x] Financial disclaimers included where appropriate

**Breaking changes documentation:**
- [x] No breaking changes

## ✅ Pre-submission Checklist

**Code quality:**
- [x] Code follows the project style guide
- [x] Self-review of code completed
- [x] Tests added/updated and passing
- [x] No linting errors (`make lint` -- verified via `ruff check`/`ruff format --check`/`lint-imports`)
- [ ] Type checking passes (`make typecheck`) -- not run in this environment; see Testing section
- [x] All tests pass (`make test`)

**Financial software standards:**
- [x] Financial disclaimers included where appropriate
- [x] No investment advice or guarantees provided
- [x] Educational purpose maintained
- [x] Data accuracy considerations documented
- [x] Risk warnings included for relevant features

**Community standards:**
- [x] PR title is descriptive and follows convention
- [x] Description clearly explains the changes
- [x] Related issues are linked
- [ ] Screenshots/examples included (if applicable) -- not applicable, backend logic fix with no UI
- [x] Ready for review

## 🤝 Review Guidance

**Areas needing special attention:**
- Confirm the sign convention: `max_drawdown` is 0 or negative throughout `BacktestMetrics`, so `min()` (not `max()`) is the correct "worst" selector -- verify no other call site assumed the old (incorrect) semantics.

## 🚀 Deployment Notes

**Environment considerations:**
- [x] No environment changes required

**Rollback plan:**
- [x] Changes are fully backward compatible

## 🎓 Educational Impact

**Learning value:**
Demonstrates a common, subtle bug class: aggregating signed risk metrics with the wrong comparison operator silently understates risk without raising any error.

---

**Additional Notes:**

## Root cause

```python
max_drawdown = max(r.metrics.max_drawdown for r in results)  # picks the mildest
```

## Fix

```python
max_drawdown = min(r.metrics.max_drawdown for r in results)
```

## Tests added

- `test_backtest_portfolio_max_drawdown_selects_worst_not_mildest`
- `test_backtest_portfolio_max_drawdown_is_order_independent`
- `test_backtest_portfolio_max_drawdown_zero_when_no_symbol_drew_down`