### PR TITLE
fix(backtesting): map ensemble strategies correctly

### DIFF
--- a/docs/api/backtesting.md
+++ b/docs/api/backtesting.md
@@ -585,6 +585,16 @@ symbols. Runs sequentially by design: `StrategyEnsemble` shares one mutable
 instance across symbols (weights mutate per call), so concurrency would
 make results order-dependent.
 
+Each entry in `base_strategies` must be a valid name from the strategy
+catalog (`backtesting_list_strategies`) -- for example `"sma_cross"`,
+`"rsi"`, `"macd"`, `"bollinger"`, `"momentum"`. Each runs its own real
+signal logic (so `"rsi"` is genuine RSI mean-reversion, not a relabeled
+SMA-crossover variant) and keeps its own template name in the result, so
+`final_strategy_weights`/`strategy_performance_analysis` stay separately
+addressable per requested strategy rather than collapsing onto one shared
+key. An unknown name raises a clear error rather than being silently
+dropped.
+
 **Tool name**: `backtesting_create_strategy_ensemble` (readOnlyHint: true)
 
 **Parameters**:
@@ -610,11 +620,11 @@ make results order-dependent.
       "symbol": "AAPL",
       "results": {
         "metrics": {"total_return": 0.21, "sharpe_ratio": 1.18},
-        "ensemble_metrics": {"strategy_weights": {"sma_cross": 0.4, "rsi": 0.3, "macd": 0.3}}
+        "ensemble_metrics": {"strategy_weights": {"SMA Crossover": 0.4, "RSI Mean Reversion": 0.3, "MACD Signal": 0.3}}
       }
     }
   ],
-  "final_strategy_weights": {"sma_cross": 0.42, "rsi": 0.28, "macd": 0.30},
+  "final_strategy_weights": {"SMA Crossover": 0.42, "RSI Mean Reversion": 0.28, "MACD Signal": 0.30},
   "strategy_performance_analysis": {"...": "..."},
   "status": "success"
 }

--- a/maverick/backtesting/service_ml.py
+++ b/maverick/backtesting/service_ml.py
@@ -23,6 +23,7 @@ from maverick.backtesting.config import BacktestingSettings
 from maverick.backtesting.service_support import (
     WALK_FORWARD_OPTIMIZATION_WINDOW_DAYS,
     SimpleMovingAverageStrategy,
+    TemplateStrategy,
     generate_wf_summary,
     resolve_dates,
     signal_fn_for,
@@ -417,22 +418,12 @@ class _ExtendedBacktestingMixin:
             strategy_list = base_strategies or ["sma_cross", "rsi", "macd"]
             start, end = resolve_dates(start_date, end_date, default_days=365)
 
-            instances: list[Strategy] = []
-            for name in strategy_list:
-                if name == "sma_cross":
-                    instances.append(SimpleMovingAverageStrategy())
-                elif name == "rsi":
-                    instances.append(
-                        SimpleMovingAverageStrategy(
-                            {"fast_period": 14, "slow_period": 28}
-                        )
-                    )
-                elif name == "macd":
-                    instances.append(
-                        SimpleMovingAverageStrategy(
-                            {"fast_period": 12, "slow_period": 26}
-                        )
-                    )
+            # Each requested name runs its own real signal logic (`TemplateStrategy` dispatches
+            # through `strategies.signals.generate_signals`), so `"rsi"`/`"macd"` are genuine
+            # RSI/MACD strategies -- not SMA-crossover variants sharing one collapsed label.
+            instances: list[Strategy] = [
+                TemplateStrategy(name) for name in strategy_list
+            ]
             if not instances:
                 raise ValueError("No valid base strategies provided")
 

--- a/maverick/backtesting/service_support.py
+++ b/maverick/backtesting/service_support.py
@@ -47,6 +47,44 @@ class SimpleMovingAverageStrategy(Strategy):
         return signal_dispatch.generate_signals(data, "sma_cross", self.parameters)
 
 
+class TemplateStrategy(Strategy):
+    """`Strategy` wrapper around any real `STRATEGY_TEMPLATES` entry, dispatching signal
+    generation through `strategies.signals.generate_signals` -- the same rule-based logic
+    `run_backtest`/`compare_strategies` use. Built for `create_strategy_ensemble`'s base
+    strategies: unlike `SimpleMovingAverageStrategy` (always SMA-crossover regardless of the
+    requested label), this makes `"rsi"` run real RSI signal logic and `"macd"` run real MACD
+    signal logic, each keeping its own template `name` -- so an ensemble's per-strategy weights
+    and performance breakdown stay separately addressable instead of collapsing multiple
+    differently-labeled base strategies onto one shared name."""
+
+    def __init__(
+        self, strategy_type: str, parameters: dict[str, Any] | None = None
+    ) -> None:
+        if strategy_type not in templates.STRATEGY_TEMPLATES:
+            available = ", ".join(templates.STRATEGY_TEMPLATES)
+            raise ValueError(
+                f"Unknown ensemble base strategy: {strategy_type!r}. Available: {available}"
+            )
+        self.strategy_type = strategy_type
+        super().__init__(
+            parameters
+            or dict(templates.STRATEGY_TEMPLATES[strategy_type]["parameters"])
+        )
+
+    @property
+    def name(self) -> str:
+        return str(templates.STRATEGY_TEMPLATES[self.strategy_type]["name"])
+
+    @property
+    def description(self) -> str:
+        return str(templates.STRATEGY_TEMPLATES[self.strategy_type]["description"])
+
+    def generate_signals(self, data: pd.DataFrame) -> tuple[pd.Series, pd.Series]:
+        return signal_dispatch.generate_signals(
+            data, self.strategy_type, self.parameters
+        )
+
+
 # Matches legacy `strategy_executor.py`'s `max_concurrent_strategies: int = 6` /
 # `batch_processing.py`'s `run_parallel_backtests(max_workers: int = 6)` -- the discoverable
 # "legacy effective parallelism" for `compare_strategies`/`backtest_portfolio`'s bounded

--- a/maverick/backtesting/service_support.py
+++ b/maverick/backtesting/service_support.py
@@ -79,6 +79,13 @@ class TemplateStrategy(Strategy):
     def description(self) -> str:
         return str(templates.STRATEGY_TEMPLATES[self.strategy_type]["description"])
 
+    def get_default_parameters(self) -> dict[str, Any]:
+        """The selected template's own default parameters -- distinct from `self.parameters`,
+        which may hold caller-supplied overrides. `Strategy.to_dict()` calls this method, so
+        without this override it would report an empty `default_parameters` regardless of
+        which template was selected."""
+        return dict(templates.STRATEGY_TEMPLATES[self.strategy_type]["parameters"])
+
     def generate_signals(self, data: pd.DataFrame) -> tuple[pd.Series, pd.Series]:
         return signal_dispatch.generate_signals(
             data, self.strategy_type, self.parameters

--- a/tests/backtesting/test_service.py
+++ b/tests/backtesting/test_service.py
@@ -526,6 +526,28 @@ async def test_template_strategy_rejects_unknown_strategy_type():
         TemplateStrategy("bogus")
 
 
+async def test_template_strategy_to_dict_exposes_real_template_defaults():
+    """Regression test: `Strategy.to_dict()` calls `get_default_parameters()`, which the base
+    class defaults to `{}`. Without overriding it, `TemplateStrategy.to_dict()` would report
+    an empty `default_parameters` even though the selected template's real defaults are known
+    via `self.strategy_type`."""
+    from maverick.backtesting.service_support import TemplateStrategy
+
+    rsi_defaults = TemplateStrategy("rsi").to_dict()["default_parameters"]
+    assert rsi_defaults == {"period": 14, "oversold": 30, "overbought": 70}
+
+    # Overriding parameters at construction must not change the template's own defaults.
+    overridden = TemplateStrategy(
+        "rsi", {"period": 21, "oversold": 25, "overbought": 75}
+    )
+    assert overridden.to_dict()["default_parameters"] == rsi_defaults
+    assert overridden.to_dict()["parameters"] == {
+        "period": 21,
+        "oversold": 25,
+        "overbought": 75,
+    }
+
+
 # ---------------------------------------------------------------------------
 # timeout
 # ---------------------------------------------------------------------------

--- a/tests/backtesting/test_service.py
+++ b/tests/backtesting/test_service.py
@@ -464,13 +464,66 @@ async def test_create_strategy_ensemble_calls_symbols_in_order_sequentially(ohlc
     assert [c[0] for c in market_data.calls] == ["MSFT", "AAPL", "GOOG"]
 
 
-async def test_create_strategy_ensemble_raises_when_no_valid_base_strategies(ohlcv):
+async def test_create_strategy_ensemble_raises_clearly_for_unknown_base_strategy(ohlcv):
+    """`TemplateStrategy` now validates each requested name eagerly against
+    `STRATEGY_TEMPLATES` and raises immediately naming the bad value, rather than silently
+    dropping it and only failing later with a generic "no valid base strategies" error."""
     service = _service(StubMarketData(ohlcv))
 
-    with pytest.raises(ValueError, match="No valid base strategies"):
+    with pytest.raises(
+        ValueError, match="Unknown ensemble base strategy: 'not_a_strategy'"
+    ):
         await service.create_strategy_ensemble(
             ["AAPL"], base_strategies=["not_a_strategy"]
         )
+
+
+async def test_create_strategy_ensemble_rsi_and_macd_use_real_signal_logic(ohlcv):
+    """Regression test for the rsi/macd mislabeling defect: requesting "rsi"/"macd" base
+    strategies must run actual RSI/MACD signal generation (via `TemplateStrategy`), not
+    SMA-crossover under a different name, and must keep three distinct, separately-addressable
+    identities in the result -- not collapse into one shared "SMA Crossover" key."""
+    service = _service(StubMarketData(ohlcv))
+
+    result = await service.create_strategy_ensemble(
+        ["AAPL"], base_strategies=["sma_cross", "rsi", "macd"]
+    )
+
+    weight_names = set(result.final_strategy_weights)
+    assert weight_names == {"SMA Crossover", "RSI Mean Reversion", "MACD Signal"}
+    performance_names = set(result.strategy_performance_analysis)
+    assert performance_names == {"SMA Crossover", "RSI Mean Reversion", "MACD Signal"}
+
+
+async def test_create_strategy_ensemble_rsi_signals_differ_from_sma_signals(ohlcv):
+    """`TemplateStrategy("rsi")` must dispatch to real RSI logic, not SMA -- confirmed by
+    comparing its generated signals directly against `TemplateStrategy("sma_cross")`'s on the
+    same frame; identical signal generation would mean the mislabeling regressed."""
+    from maverick.backtesting.service_support import TemplateStrategy
+
+    frame = ohlcv.rename(columns=str.lower)
+    sma_entries, sma_exits = TemplateStrategy("sma_cross").generate_signals(frame)
+    rsi_entries, rsi_exits = TemplateStrategy("rsi").generate_signals(frame)
+    macd_entries, macd_exits = TemplateStrategy("macd").generate_signals(frame)
+
+    assert not sma_entries.equals(rsi_entries) or not sma_exits.equals(rsi_exits)
+    assert not sma_entries.equals(macd_entries) or not sma_exits.equals(macd_exits)
+    assert not rsi_entries.equals(macd_entries) or not rsi_exits.equals(macd_exits)
+
+
+async def test_template_strategy_names_match_templates():
+    from maverick.backtesting.service_support import TemplateStrategy
+
+    assert TemplateStrategy("sma_cross").name == "SMA Crossover"
+    assert TemplateStrategy("rsi").name == "RSI Mean Reversion"
+    assert TemplateStrategy("macd").name == "MACD Signal"
+
+
+async def test_template_strategy_rejects_unknown_strategy_type():
+    from maverick.backtesting.service_support import TemplateStrategy
+
+    with pytest.raises(ValueError, match="Unknown ensemble base strategy: 'bogus'"):
+        TemplateStrategy("bogus")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📋 Pull Request Summary

**Brief description of changes:**
Fixes `backtesting_create_strategy_ensemble` so `"rsi"`/`"macd"` base strategies run real RSI/MACD signal logic instead of relabeled SMA-crossover variants.

**Related issue(s):**
- Fixes #246

## 💰 Financial Disclaimer Acknowledgment

- [x] I understand this is educational software and not financial advice
- [x] Any financial analysis features include appropriate disclaimers
- [x] This PR maintains the educational/personal-use focus of the project

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements to documentation)
- [ ] 🔧 Refactor (code changes that neither fix bugs nor add features)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (dependencies, build tools, etc.)

## 🎯 Component Areas

**Primary areas affected:**
- [ ] Data fetching (Tiingo, Yahoo Finance, FRED)
- [ ] Technical analysis calculations
- [ ] Stock screening strategies
- [ ] Portfolio analysis and optimization
- [x] MCP server/tools implementation (backtesting domain)
- [ ] Database operations and models
- [ ] Caching (Redis/in-memory)
- [ ] Claude Desktop integration
- [ ] Development tools and setup
- [x] Documentation and examples

## 🔧 Implementation Details

**Technical approach:**
`create_strategy_ensemble` accepted `base_strategies` names like `"sma_cross"`, `"rsi"`, `"macd"`, but `"rsi"` and `"macd"` were both instantiated as `SimpleMovingAverageStrategy` (14/28-period and 12/26-period SMA-crossover variants) instead of running actual RSI or MACD signal logic. Because `SimpleMovingAverageStrategy.name` is hardcoded to `"SMA Crossover"`, this also collapsed `final_strategy_weights`/`strategy_performance_analysis` onto one shared key.

**Key changes:**
- Added `TemplateStrategy` (`maverick/backtesting/service_support.py`), a thin `Strategy` wrapper that dispatches through the existing `strategies.signals.generate_signals` catalog -- the same rule-based logic `run_backtest`/`compare_strategies` already use for every strategy name. No new strategy types were introduced.
- `create_strategy_ensemble` now builds `TemplateStrategy(name)` per requested base strategy, so each keeps its own real signal logic and template name.
- Unknown strategy names now raise `ValueError` immediately, naming the bad value.
- Overrode `TemplateStrategy.get_default_parameters()` (found via CodeRabbit review on this PR) so `Strategy.to_dict()`'s `default_parameters` field reports the selected template's real defaults instead of the base class's empty `{}`.

**Dependencies:**
- [x] No new dependencies added

## 🧪 Testing

**Testing performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (live MCP tool call with a 3-strategy ensemble, confirming 3 distinct weight/performance keys)
- [ ] Tested with Claude Desktop
- [ ] Tested with different data sources
- [ ] Performance testing completed

**Test scenarios covered:**
- [x] Happy path functionality
- [x] Error handling and edge cases (unknown strategy name)
- [ ] Data validation and sanitization
- [ ] API rate limiting compliance
- [ ] Database operations
- [ ] Cache behavior

**Manual testing:**
```bash
uv run pytest tests/backtesting/ tests/server/
uv run --extra dev ruff check .
uv run --extra dev ruff format --check .
uv run lint-imports
```
Result: 245 passed, 5 skipped (pre-existing, Research-extra-gated), 0 failed. `lint-imports`: 14/14 contracts kept. `ruff check`/`ruff format --check`: clean.

`make typecheck` could not be verified in this environment: it requires `--extra research` to resolve `maverick.backtesting.strategies.parser`'s lazy BYOK-LLM import (a pre-existing condition unrelated to this PR -- `parser.py` is untouched by this diff), and this environment does not install the `[research]` extra. Not claiming this check as passed.

## 📊 Financial Analysis Impact

**Financial calculations:**
- [ ] No financial calculations affected
- [ ] New financial calculations added (validated for accuracy)
- [x] Existing calculations modified (thoroughly tested)
- [x] All calculations include appropriate disclaimers

**Data providers:**
- [x] No data provider changes

**Market data handling:**
- [ ] Historical data processing
- [ ] Real-time data integration
- [x] Technical indicator calculations (RSI/MACD signal generation now genuinely runs where requested)
- [ ] Screening algorithm changes

## 🔒 Security Considerations

**Security checklist:**
- [x] No hardcoded secrets or credentials
- [x] Input validation implemented (unknown strategy names now rejected explicitly)
- [x] Error handling doesn't leak sensitive information
- [x] API keys handled securely via environment variables (unaffected)
- [x] SQL injection prevention verified (not applicable -- no SQL in this path)
- [x] Rate limiting respected for external APIs (unaffected)

## 📚 Documentation

**Documentation updates:**
- [x] Code comments added/updated
- [ ] README.md updated (if needed)
- [x] API documentation updated (`docs/api/backtesting.md`)
- [ ] Examples/tutorials added
- [x] Financial disclaimers included where appropriate

**Breaking changes documentation:**
- [x] No breaking changes (the return *shape* is unchanged; only the previously-mislabeled `"rsi"`/`"macd"` result values/keys now reflect real strategy identities)

## ✅ Pre-submission Checklist

**Code quality:**
- [x] Code follows the project style guide
- [x] Self-review of code completed
- [x] Tests added/updated and passing
- [x] No linting errors (`make lint` -- verified via `ruff check`/`ruff format --check`/`lint-imports`)
- [ ] Type checking passes (`make typecheck`) -- not run in this environment; see Testing section
- [x] All tests pass (`make test`)

**Financial software standards:**
- [x] Financial disclaimers included where appropriate
- [x] No investment advice or guarantees provided
- [x] Educational purpose maintained
- [x] Data accuracy considerations documented
- [x] Risk warnings included for relevant features

**Community standards:**
- [x] PR title is descriptive and follows convention
- [x] Description clearly explains the changes
- [x] Related issues are linked
- [ ] Screenshots/examples included (if applicable) -- not applicable, backend logic fix with no UI
- [x] Ready for review

## 🤝 Review Guidance

**Areas needing special attention:**
- `SimpleMovingAverageStrategy` (used elsewhere, e.g. `run_ml_strategy_backtest`'s "ensemble"/"regime_aware" ML branches) is deliberately left untouched -- it's a different, intentional SMA-only building block for those paths, not part of this defect.

## 🚀 Deployment Notes

**Environment considerations:**
- [x] No environment changes required

**Rollback plan:**
- [x] Changes are fully backward compatible

## 🎓 Educational Impact

**Learning value:**
Illustrates why a `Strategy` subclass's `name`/`get_default_parameters()` should always reflect what it actually does -- a hardcoded label can silently hide that "3 strategies" are really 1 strategy run 3 times.

---

**Additional Notes:**

## Tests added

- `test_create_strategy_ensemble_rsi_and_macd_use_real_signal_logic`
- `test_create_strategy_ensemble_rsi_signals_differ_from_sma_signals`
- `test_template_strategy_names_match_templates`
- `test_template_strategy_rejects_unknown_strategy_type`
- `test_template_strategy_to_dict_exposes_real_template_defaults` (added for the `get_default_parameters` fix)
- Updated `test_create_strategy_ensemble_raises_when_no_valid_base_strategies` -> `test_create_strategy_ensemble_raises_clearly_for_unknown_base_strategy`
