### PR TITLE
fix(backtesting): correct regime fallback and probabilities

### DIFF
--- a/docs/api/backtesting.md
+++ b/docs/api/backtesting.md
@@ -551,12 +551,25 @@ Train a random-forest ML predictor model for trading signals.
 
 Analyze market regimes (bear/sideways/bull) for a symbol using ML methods.
 
+`method="hmm"` fits an `sklearn.mixture.GaussianMixture`, not a genuine
+Hidden Markov Model -- the name is kept for backward compatibility.
+`method="kmeans"` is real k-means clustering; `method="threshold"` is a
+zero-model rule-based classifier on trend slope and volatility. The
+returned `method` field reports what was **actually** used, which can
+differ from the request: fitting silently falls back to `"threshold"` when
+there isn't enough history to fit a genuine statistical model (in practice,
+this tool's own default 365-day lookback is usually *not* enough for
+`n_regimes=3`; use a longer `start_date`/`end_date` range to fit a real
+model). Each `recent_regime_history` entry's `probabilities` are the fitted
+model's real posterior when one exists, otherwise an honest one-hot vector
+at the assigned regime -- never a fabricated uniform distribution.
+
 **Tool name**: `backtesting_analyze_market_regimes` (readOnlyHint: true)
 
 **Parameters**:
 - `symbol` (str, required)
 - `start_date`, `end_date` (str, optional)
-- `method` (str, default: "hmm"): `hmm`, `kmeans`, or `threshold`
+- `method` (str, default: "hmm"): `hmm` (Gaussian-mixture clustering; see above), `kmeans`, or `threshold`
 - `n_regimes` (int, default: 3)
 - `lookback_period` (int, default: 50)
 

--- a/maverick/backtesting/service_ml.py
+++ b/maverick/backtesting/service_ml.py
@@ -383,10 +383,12 @@ class _ExtendedBacktestingMixin:
             return MarketRegimeAnalysis(
                 symbol=symbol,
                 analysis_period=f"{start} to {end}",
-                # `detector.method`, not the requested `method`: `fit_regimes` silently
-                # switches to "threshold" when there isn't enough data to fit a genuine
-                # statistical model (see `MarketRegimeDetector.fit_regimes`) -- reporting the
-                # originally-requested value here would misrepresent what was actually used.
+                # `detector.method`, not the requested `method`: `fit_regimes`
+                # silently switches to "threshold" when there isn't enough
+                # data to fit a genuine statistical model (see
+                # `MarketRegimeDetector.fit_regimes`) -- reporting the
+                # originally-requested value here would misrepresent what was
+                # actually used.
                 method=detector.method,
                 n_regimes=n_regimes,
                 # Hardcoded regardless of n_regimes -- a legacy quirk, preserved verbatim.

--- a/maverick/backtesting/service_ml.py
+++ b/maverick/backtesting/service_ml.py
@@ -383,7 +383,11 @@ class _ExtendedBacktestingMixin:
             return MarketRegimeAnalysis(
                 symbol=symbol,
                 analysis_period=f"{start} to {end}",
-                method=method,
+                # `detector.method`, not the requested `method`: `fit_regimes` silently
+                # switches to "threshold" when there isn't enough data to fit a genuine
+                # statistical model (see `MarketRegimeDetector.fit_regimes`) -- reporting the
+                # originally-requested value here would misrepresent what was actually used.
+                method=detector.method,
                 n_regimes=n_regimes,
                 # Hardcoded regardless of n_regimes -- a legacy quirk, preserved verbatim.
                 regime_names={

--- a/maverick/backtesting/service_ml.py
+++ b/maverick/backtesting/service_ml.py
@@ -383,13 +383,7 @@ class _ExtendedBacktestingMixin:
             return MarketRegimeAnalysis(
                 symbol=symbol,
                 analysis_period=f"{start} to {end}",
-                # `detector.method`, not the requested `method`: `fit_regimes`
-                # silently switches to "threshold" when there isn't enough
-                # data to fit a genuine statistical model (see
-                # `MarketRegimeDetector.fit_regimes`) -- reporting the
-                # originally-requested value here would misrepresent what was
-                # actually used.
-                method=detector.method,
+                method=detector.method,  # what was used; fit_regimes may fall back
                 n_regimes=n_regimes,
                 # Hardcoded regardless of n_regimes -- a legacy quirk, preserved verbatim.
                 regime_names={

--- a/maverick/backtesting/strategies/ml/regime_detector.py
+++ b/maverick/backtesting/strategies/ml/regime_detector.py
@@ -35,7 +35,15 @@ logger = logging.getLogger(__name__)
 
 
 class MarketRegimeDetector:
-    """Detect market regimes using various statistical methods."""
+    """Detect market regimes using various statistical methods.
+
+    Despite its name, `method="hmm"` does not implement a Hidden Markov Model -- there is no
+    transition matrix or temporal state-sequence modeling anywhere in this class. It fits an
+    `sklearn.mixture.GaussianMixture` (static clustering over a rolling window of regime
+    features) and reuses the "hmm" label for backward compatibility with existing callers/tool
+    schemas. `method="kmeans"` is genuine k-means clustering; `method="threshold"` is a
+    zero-model rule-based classifier on trend slope and volatility (see
+    `detect_regime_threshold`)."""
 
     def __init__(
         self,
@@ -47,7 +55,10 @@ class MarketRegimeDetector:
         """Initialize regime detector.
 
         Args:
-            method: Detection method ('hmm', 'kmeans', 'threshold')
+            method: Detection method. `'hmm'` -- misnomer kept for backward compatibility;
+                actually fits `sklearn.mixture.GaussianMixture`, not a real Hidden Markov Model
+                (see class docstring). `'kmeans'` -- genuine k-means clustering. `'threshold'`
+                -- rule-based trend/volatility classifier, no fitted model.
             n_regimes: Number of market regimes to detect
             lookback_period: Period for regime detection
             random_state: Optional seed. `None` (default) preserves legacy
@@ -147,6 +158,22 @@ class MarketRegimeDetector:
         else:
             return 1  # Sideways/uncertain market
 
+    def _fall_back_to_threshold_method(self, reason: str) -> None:
+        """Switch to the rule-based threshold method, matching the already-established
+        convention for an explicit `method="threshold"` request or a `model.fit()` exception
+        (`self.method = "threshold"; self.is_fitted = True`). Every "can't fit a genuine
+        statistical model" branch in `fit_regimes` now converges on this one state, instead of
+        some branches claiming `is_fitted = True` while leaving `self.method` unchanged and
+        `self.scaler`/`self.model` never actually fit -- which previously let
+        `get_regime_probabilities` reach an unfitted `StandardScaler`, raise `NotFittedError`,
+        and silently fabricate a uniform distribution, while `detect_current_regime`
+        independently and separately fell back to the same threshold method through its own,
+        differently-triggered exception handling. `detector.method` (surfaced by
+        `analyze_market_regimes`) now honestly reports "threshold" in every such case."""
+        logger.warning(f"Falling back to threshold regime method: {reason}")
+        self.method = "threshold"
+        self.is_fitted = True
+
     def fit_regimes(self, data: DataFrame) -> None:
         """Fit regime detection model to historical data with enhanced robustness.
 
@@ -161,10 +188,10 @@ class MarketRegimeDetector:
             # Need sufficient data for stable regime detection
             min_required_samples = max(50, self.n_regimes * 20)
             if len(data) < min_required_samples + self.lookback_period:
-                logger.warning(
-                    f"Insufficient data for regime fitting: {len(data)} < {min_required_samples + self.lookback_period}"
+                self._fall_back_to_threshold_method(
+                    f"insufficient data for regime fitting: {len(data)} < "
+                    f"{min_required_samples + self.lookback_period}"
                 )
-                self.is_fitted = True
                 return
 
             # Extract features for regime detection with temporal consistency
@@ -191,26 +218,26 @@ class MarketRegimeDetector:
                     feature_list.append(features)
 
             if len(feature_list) < min_required_samples:
-                logger.warning(
-                    f"Insufficient valid samples for regime fitting: {len(feature_list)} < {min_required_samples}"
+                self._fall_back_to_threshold_method(
+                    f"insufficient valid samples for regime fitting: "
+                    f"{len(feature_list)} < {min_required_samples}"
                 )
-                self.is_fitted = True
                 return
 
             # Ensure we have valid feature_list before creating array
             if len(feature_list) == 0:
-                logger.warning(
-                    "Empty feature list after filtering, cannot create feature matrix"
+                self._fall_back_to_threshold_method(
+                    "empty feature list after filtering, cannot create feature matrix"
                 )
-                self.is_fitted = True
                 return
 
             X = np.array(feature_list)
 
             # Additional data quality checks
             if X.size == 0:
-                logger.warning("Empty feature matrix, cannot fit regime detector")
-                self.is_fitted = True
+                self._fall_back_to_threshold_method(
+                    "empty feature matrix, cannot fit regime detector"
+                )
                 return
             elif np.any(np.isnan(X)) or np.any(np.isinf(X)):
                 logger.warning("Found NaN or inf values in feature matrix, cleaning...")
@@ -278,14 +305,12 @@ class MarketRegimeDetector:
                     )
 
             except Exception as model_error:
-                logger.error(f"Model fitting failed: {model_error}")
-                logger.info("Falling back to threshold method")
-                self.method = "threshold"  # Fallback to threshold method
-                self.is_fitted = True
+                self._fall_back_to_threshold_method(
+                    f"model fitting failed: {model_error}"
+                )
 
         except Exception as e:
-            logger.error(f"Error fitting regime detector: {e}")
-            self.is_fitted = True  # Allow fallback to threshold method
+            self._fall_back_to_threshold_method(f"error fitting regime detector: {e}")
 
     def detect_current_regime(self, data: DataFrame) -> int:
         """Detect current market regime with enhanced error handling.
@@ -353,29 +378,43 @@ class MarketRegimeDetector:
             logger.error(f"Error detecting current regime: {e}")
             return self.detect_regime_threshold(data)  # Always fallback to threshold
 
+    def _one_hot_via_threshold_fallback(self, data: DataFrame) -> np.ndarray:
+        """Deterministic, honestly-labeled fallback: a one-hot vector at whatever regime
+        `detect_current_regime` actually resolves to (itself falling back to the rule-based
+        threshold classifier when no fitted probabilistic model is usable). This reflects a
+        real hard-classifier decision -- unlike a flat uniform array, which asserts nothing
+        about how the regime was actually chosen and previously masked exactly this condition
+        (see `fit_regimes`'s docstring note)."""
+        regime = self.detect_current_regime(data)
+        probs = np.zeros(self.n_regimes)
+        probs[regime] = 1.0
+        return probs
+
     def get_regime_probabilities(self, data: DataFrame) -> np.ndarray:
         """Get probabilities for each regime.
+
+        Returns the fitted probabilistic model's actual `predict_proba` output when one is
+        genuinely available; otherwise an honest one-hot vector reflecting the regime that was
+        actually assigned (see `_one_hot_via_threshold_fallback`). Never returns a fabricated
+        flat/uniform distribution disconnected from the real classification decision -- that
+        previously happened whenever the statistical model wasn't genuinely fitted (see
+        `fit_regimes`) and `self.scaler.transform(...)` raised `NotFittedError`, which this
+        method's own `except` swallowed into `np.ones(n) / n`.
 
         Args:
             data: Recent price data
 
         Returns:
-            Array of regime probabilities
+            Array of regime probabilities, summing to ~1.
         """
         if not self.is_fitted or self.method == "threshold":
-            # For threshold method, return deterministic probabilities
-            regime = self.detect_current_regime(data)
-            probs = np.zeros(self.n_regimes)
-            probs[regime] = 1.0
-            return probs
+            return self._one_hot_via_threshold_fallback(data)
 
         try:
             features = self.extract_regime_features(data)
 
-            if len(features) == 0:
-                return np.ones(self.n_regimes) / self.n_regimes
-            elif features.size > 0 and np.any(np.isnan(features)):
-                return np.ones(self.n_regimes) / self.n_regimes
+            if len(features) == 0 or (features.size > 0 and np.any(np.isnan(features))):
+                return self._one_hot_via_threshold_fallback(data)
 
             assert self.model is not None  # method != "threshold" implies set
             X = self.scaler.transform([features])
@@ -395,4 +434,4 @@ class MarketRegimeDetector:
 
         except Exception as e:
             logger.error(f"Error getting regime probabilities: {e}")
-            return np.ones(self.n_regimes) / self.n_regimes
+            return self._one_hot_via_threshold_fallback(data)

--- a/maverick/backtesting/strategies/ml/regime_detector.py
+++ b/maverick/backtesting/strategies/ml/regime_detector.py
@@ -37,13 +37,14 @@ logger = logging.getLogger(__name__)
 class MarketRegimeDetector:
     """Detect market regimes using various statistical methods.
 
-    Despite its name, `method="hmm"` does not implement a Hidden Markov Model -- there is no
-    transition matrix or temporal state-sequence modeling anywhere in this class. It fits an
-    `sklearn.mixture.GaussianMixture` (static clustering over a rolling window of regime
-    features) and reuses the "hmm" label for backward compatibility with existing callers/tool
-    schemas. `method="kmeans"` is genuine k-means clustering; `method="threshold"` is a
-    zero-model rule-based classifier on trend slope and volatility (see
-    `detect_regime_threshold`)."""
+    Despite its name, `method="hmm"` does not implement a Hidden Markov Model
+    -- there is no transition matrix or temporal state-sequence modeling
+    anywhere in this class. It fits an `sklearn.mixture.GaussianMixture`
+    (static clustering over a rolling window of regime features) and reuses
+    the "hmm" label for backward compatibility with existing callers/tool
+    schemas. `method="kmeans"` is genuine k-means clustering;
+    `method="threshold"` is a zero-model rule-based classifier on trend slope
+    and volatility (see `detect_regime_threshold`)."""
 
     def __init__(
         self,
@@ -55,10 +56,11 @@ class MarketRegimeDetector:
         """Initialize regime detector.
 
         Args:
-            method: Detection method. `'hmm'` -- misnomer kept for backward compatibility;
-                actually fits `sklearn.mixture.GaussianMixture`, not a real Hidden Markov Model
-                (see class docstring). `'kmeans'` -- genuine k-means clustering. `'threshold'`
-                -- rule-based trend/volatility classifier, no fitted model.
+            method: Detection method. `'hmm'` -- misnomer kept for backward
+                compatibility; actually fits `sklearn.mixture.GaussianMixture`,
+                not a real Hidden Markov Model (see class docstring).
+                `'kmeans'` -- genuine k-means clustering. `'threshold'` --
+                rule-based trend/volatility classifier, no fitted model.
             n_regimes: Number of market regimes to detect
             lookback_period: Period for regime detection
             random_state: Optional seed. `None` (default) preserves legacy
@@ -159,17 +161,21 @@ class MarketRegimeDetector:
             return 1  # Sideways/uncertain market
 
     def _fall_back_to_threshold_method(self, reason: str) -> None:
-        """Switch to the rule-based threshold method, matching the already-established
-        convention for an explicit `method="threshold"` request or a `model.fit()` exception
-        (`self.method = "threshold"; self.is_fitted = True`). Every "can't fit a genuine
-        statistical model" branch in `fit_regimes` now converges on this one state, instead of
-        some branches claiming `is_fitted = True` while leaving `self.method` unchanged and
-        `self.scaler`/`self.model` never actually fit -- which previously let
-        `get_regime_probabilities` reach an unfitted `StandardScaler`, raise `NotFittedError`,
-        and silently fabricate a uniform distribution, while `detect_current_regime`
-        independently and separately fell back to the same threshold method through its own,
-        differently-triggered exception handling. `detector.method` (surfaced by
-        `analyze_market_regimes`) now honestly reports "threshold" in every such case."""
+        """Switch to the rule-based threshold method, matching the
+        already-established convention for an explicit `method="threshold"`
+        request or a `model.fit()` exception (`self.method = "threshold";
+        self.is_fitted = True`). Every "can't fit a genuine statistical
+        model" branch in `fit_regimes` now converges on this one state,
+        instead of some branches claiming `is_fitted = True` while leaving
+        `self.method` unchanged and `self.scaler`/`self.model` never
+        actually fit -- which previously let `get_regime_probabilities`
+        reach an unfitted `StandardScaler`, raise `NotFittedError`, and
+        silently fabricate a uniform distribution, while
+        `detect_current_regime` independently and separately fell back to
+        the same threshold method through its own, differently-triggered
+        exception handling. `detector.method` (surfaced by
+        `analyze_market_regimes`) now honestly reports "threshold" in every
+        such case."""
         logger.warning(f"Falling back to threshold regime method: {reason}")
         self.method = "threshold"
         self.is_fitted = True
@@ -379,13 +385,20 @@ class MarketRegimeDetector:
             return self.detect_regime_threshold(data)  # Always fallback to threshold
 
     def _one_hot_via_threshold_fallback(self, data: DataFrame) -> np.ndarray:
-        """Deterministic, honestly-labeled fallback: a one-hot vector at whatever regime
-        `detect_current_regime` actually resolves to (itself falling back to the rule-based
-        threshold classifier when no fitted probabilistic model is usable). This reflects a
-        real hard-classifier decision -- unlike a flat uniform array, which asserts nothing
-        about how the regime was actually chosen and previously masked exactly this condition
-        (see `fit_regimes`'s docstring note)."""
-        regime = self.detect_current_regime(data)
+        """Deterministic, honestly-labeled fallback: a one-hot vector at
+        whatever regime `detect_current_regime` actually resolves to (itself
+        falling back to the rule-based threshold classifier when no fitted
+        probabilistic model is usable). This reflects a real hard-classifier
+        decision -- unlike a flat uniform array, which asserts nothing about
+        how the regime was actually chosen and previously masked exactly
+        this condition (see `fit_regimes`'s docstring note).
+
+        `detect_regime_threshold` always returns one of exactly three
+        hardcoded labels (0/1/2) regardless of `self.n_regimes`, so the
+        label is clamped into `[0, n_regimes)` before indexing -- otherwise
+        a detector configured with `n_regimes < 3` could raise `IndexError`
+        here instead of returning a valid one-hot vector."""
+        regime = min(self.detect_current_regime(data), self.n_regimes - 1)
         probs = np.zeros(self.n_regimes)
         probs[regime] = 1.0
         return probs
@@ -393,12 +406,14 @@ class MarketRegimeDetector:
     def get_regime_probabilities(self, data: DataFrame) -> np.ndarray:
         """Get probabilities for each regime.
 
-        Returns the fitted probabilistic model's actual `predict_proba` output when one is
-        genuinely available; otherwise an honest one-hot vector reflecting the regime that was
-        actually assigned (see `_one_hot_via_threshold_fallback`). Never returns a fabricated
-        flat/uniform distribution disconnected from the real classification decision -- that
-        previously happened whenever the statistical model wasn't genuinely fitted (see
-        `fit_regimes`) and `self.scaler.transform(...)` raised `NotFittedError`, which this
+        Returns the fitted probabilistic model's actual `predict_proba`
+        output when one is genuinely available; otherwise an honest one-hot
+        vector reflecting the regime that was actually assigned (see
+        `_one_hot_via_threshold_fallback`). Never returns a fabricated
+        flat/uniform distribution disconnected from the real classification
+        decision -- that previously happened whenever the statistical model
+        wasn't genuinely fitted (see `fit_regimes`) and
+        `self.scaler.transform(...)` raised `NotFittedError`, which this
         method's own `except` swallowed into `np.ones(n) / n`.
 
         Args:

--- a/maverick/backtesting/tools_ml.py
+++ b/maverick/backtesting/tools_ml.py
@@ -87,7 +87,16 @@ async def backtesting_analyze_market_regimes(
     n_regimes: int = 3,
     lookback_period: int = 50,
 ) -> dict[str, Any]:
-    """Analyze market regimes (bear/sideways/bull) for a symbol using ML methods."""
+    """Analyze market regimes (bear/sideways/bull) for a symbol using ML methods.
+
+    `method="hmm"` (the default) fits an `sklearn.mixture.GaussianMixture`, not a genuine
+    Hidden Markov Model -- the name is kept for backward compatibility. `method="kmeans"` is
+    real k-means clustering; `method="threshold"` is a zero-model rule-based classifier. The
+    returned `method` field reports what was actually used, which can differ from the request
+    if there wasn't enough history to fit a statistical model (silently falls back to
+    "threshold"). Each history entry's `probabilities` are the fitted model's real posterior
+    when one exists, otherwise an honest one-hot at the assigned regime -- never a fabricated
+    uniform distribution."""
     try:
         service = require_service()
         result = await service.analyze_market_regimes(

--- a/maverick/backtesting/tools_ml.py
+++ b/maverick/backtesting/tools_ml.py
@@ -89,13 +89,15 @@ async def backtesting_analyze_market_regimes(
 ) -> dict[str, Any]:
     """Analyze market regimes (bear/sideways/bull) for a symbol using ML methods.
 
-    `method="hmm"` (the default) fits an `sklearn.mixture.GaussianMixture`, not a genuine
-    Hidden Markov Model -- the name is kept for backward compatibility. `method="kmeans"` is
-    real k-means clustering; `method="threshold"` is a zero-model rule-based classifier. The
-    returned `method` field reports what was actually used, which can differ from the request
-    if there wasn't enough history to fit a statistical model (silently falls back to
-    "threshold"). Each history entry's `probabilities` are the fitted model's real posterior
-    when one exists, otherwise an honest one-hot at the assigned regime -- never a fabricated
+    `method="hmm"` (the default) fits an `sklearn.mixture.GaussianMixture`,
+    not a genuine Hidden Markov Model -- the name is kept for backward
+    compatibility. `method="kmeans"` is real k-means clustering;
+    `method="threshold"` is a zero-model rule-based classifier. The returned
+    `method` field reports what was actually used, which can differ from the
+    request if there wasn't enough history to fit a statistical model
+    (silently falls back to "threshold"). Each history entry's
+    `probabilities` are the fitted model's real posterior when one exists,
+    otherwise an honest one-hot at the assigned regime -- never a fabricated
     uniform distribution."""
     try:
         service = require_service()

--- a/maverick/backtesting/types.py
+++ b/maverick/backtesting/types.py
@@ -356,8 +356,9 @@ class MLTrainingResult(BaseModel):
 class RegimeHistoryEntry(BaseModel):
     date: str
     regime: int
-    # The fitted model's real posterior probability per regime when one exists; otherwise an
-    # honest one-hot vector at `regime` (never a fabricated uniform distribution -- see
+    # The fitted model's real posterior probability per regime when one
+    # exists; otherwise an honest one-hot vector at `regime` (never a
+    # fabricated uniform distribution -- see
     # `MarketRegimeDetector.get_regime_probabilities`). Sums to ~1 either way.
     probabilities: list[float]
 
@@ -367,10 +368,12 @@ class MarketRegimeAnalysis(BaseModel):
 
     symbol: str
     analysis_period: str
-    # The method actually used, which can differ from what was requested: `fit_regimes` falls
-    # back to `"threshold"` when there isn't enough history to fit a genuine statistical model.
-    # `"hmm"` fits `sklearn.mixture.GaussianMixture` -- not a real Hidden Markov Model; the name
-    # is kept for backward compatibility (see `MarketRegimeDetector`'s docstring).
+    # The method actually used, which can differ from what was requested:
+    # `fit_regimes` falls back to `"threshold"` when there isn't enough
+    # history to fit a genuine statistical model. `"hmm"` fits
+    # `sklearn.mixture.GaussianMixture` -- not a real Hidden Markov Model;
+    # the name is kept for backward compatibility (see
+    # `MarketRegimeDetector`'s docstring).
     method: str
     n_regimes: int
     regime_names: dict[int, str]

--- a/maverick/backtesting/types.py
+++ b/maverick/backtesting/types.py
@@ -356,6 +356,9 @@ class MLTrainingResult(BaseModel):
 class RegimeHistoryEntry(BaseModel):
     date: str
     regime: int
+    # The fitted model's real posterior probability per regime when one exists; otherwise an
+    # honest one-hot vector at `regime` (never a fabricated uniform distribution -- see
+    # `MarketRegimeDetector.get_regime_probabilities`). Sums to ~1 either way.
     probabilities: list[float]
 
 
@@ -364,6 +367,10 @@ class MarketRegimeAnalysis(BaseModel):
 
     symbol: str
     analysis_period: str
+    # The method actually used, which can differ from what was requested: `fit_regimes` falls
+    # back to `"threshold"` when there isn't enough history to fit a genuine statistical model.
+    # `"hmm"` fits `sklearn.mixture.GaussianMixture` -- not a real Hidden Markov Model; the name
+    # is kept for backward compatibility (see `MarketRegimeDetector`'s docstring).
     method: str
     n_regimes: int
     regime_names: dict[int, str]

--- a/tests/backtesting/test_ml_regime_aware.py
+++ b/tests/backtesting/test_ml_regime_aware.py
@@ -109,10 +109,10 @@ class TestMarketRegimeDetector:
         `fit_regimes` must honestly switch `self.method` to `"threshold"` (matching the
         existing explicit-request/model.fit()-exception convention), not merely claim
         `is_fitted = True` while leaving `self.method` at `"kmeans"`/`"hmm"` with
-        `self.scaler`/`self.model` never actually fit -- the previous behavior let
-        `get_regime_probabilities` reach an unfitted `StandardScaler`, raise `NotFittedError`,
-        and silently fabricate a uniform distribution (see `regime_detector.py`'s
-        `fit_regimes`)."""
+        `self.scaler`/`self.model` never actually fit -- the previous behavior
+        let `get_regime_probabilities` reach an unfitted `StandardScaler`,
+        raise `NotFittedError`, and silently fabricate a uniform distribution
+        (see `regime_detector.py`'s `fit_regimes`)."""
         det = MarketRegimeDetector(method="kmeans", n_regimes=3, lookback_period=50)
         det.fit_regimes(pd.DataFrame({"close": np.linspace(100, 110, 60)}))
         assert det.is_fitted
@@ -121,9 +121,9 @@ class TestMarketRegimeDetector:
         assert det.model is not None
         assert not hasattr(det.model, "cluster_centers_")
 
-        # Both regime detection and probability reporting must now consistently use the
-        # rule-based threshold path, and probabilities must be an honest one-hot -- never the
-        # old fabricated uniform distribution.
+        # Both regime detection and probability reporting must now consistently
+        # use the rule-based threshold path, and probabilities must be an
+        # honest one-hot -- never the old fabricated uniform distribution.
         data = pd.DataFrame({"close": np.linspace(100, 110, 60)})
         regime = det.detect_current_regime(data)
         probs = det.get_regime_probabilities(data)
@@ -134,17 +134,19 @@ class TestMarketRegimeDetector:
 
 
 class TestRegimeProbabilities:
-    """Regression tests for the uniform-probability defect: `get_regime_probabilities` must
-    return the fitted model's real posterior when genuinely available, and an honest one-hot
-    (never a fabricated uniform distribution) otherwise."""
+    """Regression tests for the uniform-probability defect:
+    `get_regime_probabilities` must return the fitted model's real posterior
+    when genuinely available, and an honest one-hot (never a fabricated
+    uniform distribution) otherwise."""
 
     @staticmethod
     def _well_separated_series(
         n_per_segment: int = 200, seed: int = 11
     ) -> pd.DataFrame:
-        """Repeated bull/bear/sideways legs -- enough data (>= the 60-sample fit minimum for
-        `n_regimes=3`) and clearly distinct regimes for the fitted model to express real,
-        confident, non-uniform posteriors rather than a degenerate/insufficient-data fit."""
+        """Repeated bull/bear/sideways legs -- enough data (>= the 60-sample
+        fit minimum for `n_regimes=3`) and clearly distinct regimes for the
+        fitted model to express real, confident, non-uniform posteriors
+        rather than a degenerate/insufficient-data fit."""
         rng = np.random.default_rng(seed)
         segments = []
         for _ in range(3):
@@ -179,16 +181,17 @@ class TestRegimeProbabilities:
         assert int(np.argmax(probs)) == regime
 
     def test_hmm_method_is_gaussian_mixture_not_hidden_markov_model(self):
-        """Locks in the naming decision: `"hmm"` is documented as -- and actually
-        instantiates -- `sklearn.mixture.GaussianMixture`, kept for backward compatibility
-        rather than a real Hidden Markov Model."""
+        """Locks in the naming decision: `"hmm"` is documented as -- and
+        actually instantiates -- `sklearn.mixture.GaussianMixture`, kept for
+        backward compatibility rather than a real Hidden Markov Model."""
         det = MarketRegimeDetector(method="hmm", n_regimes=3, lookback_period=50)
         assert type(det.model).__name__ == "GaussianMixture"
 
     def test_probability_lookup_failure_falls_back_to_one_hot_not_uniform(self):
-        """If computing real probabilities raises for any reason after a genuine fit, the
-        fallback must be an honest one-hot tied to the actual classification decision -- never
-        the previous `np.ones(n) / n` fabrication."""
+        """If computing real probabilities raises for any reason after a
+        genuine fit, the fallback must be an honest one-hot tied to the
+        actual classification decision -- never the previous `np.ones(n) / n`
+        fabrication."""
         data = self._well_separated_series()
         det = MarketRegimeDetector(method="hmm", n_regimes=3, lookback_period=50)
         det.fit_regimes(data)
@@ -205,6 +208,25 @@ class TestRegimeProbabilities:
         assert probs.sum() == pytest.approx(1.0)
         assert probs[regime] == pytest.approx(1.0)
         assert not np.allclose(probs, 1 / 3)
+
+    def test_threshold_fallback_does_not_index_error_with_fewer_than_three_regimes(
+        self,
+    ):
+        """Regression test (found via CodeRabbit review): `detect_regime_threshold` always
+        returns one of exactly three hardcoded labels (0/1/2) regardless of `n_regimes`, so a
+        detector configured with `n_regimes=2` could previously raise `IndexError` inside
+        `_one_hot_via_threshold_fallback` whenever the threshold classifier returned label 2.
+        The label must be clamped into `[0, n_regimes)` instead."""
+        det = MarketRegimeDetector(method="threshold", n_regimes=2)
+        # A clear uptrend makes `detect_regime_threshold` return 2 (bull/trending), which is
+        # out of range for a 2-regime detector.
+        data = pd.DataFrame({"close": np.linspace(100, 130, 25)})
+
+        probs = det.get_regime_probabilities(data)
+
+        assert probs.shape == (2,)
+        assert probs.sum() == pytest.approx(1.0)
+        assert probs[-1] == pytest.approx(1.0)
 
 
 class TestRegimeAwareStrategy:

--- a/tests/backtesting/test_ml_regime_aware.py
+++ b/tests/backtesting/test_ml_regime_aware.py
@@ -105,12 +105,106 @@ class TestMarketRegimeDetector:
         )
 
     def test_insufficient_data_falls_back_to_threshold(self):
+        """Regression test: with too little data to fit a genuine statistical model,
+        `fit_regimes` must honestly switch `self.method` to `"threshold"` (matching the
+        existing explicit-request/model.fit()-exception convention), not merely claim
+        `is_fitted = True` while leaving `self.method` at `"kmeans"`/`"hmm"` with
+        `self.scaler`/`self.model` never actually fit -- the previous behavior let
+        `get_regime_probabilities` reach an unfitted `StandardScaler`, raise `NotFittedError`,
+        and silently fabricate a uniform distribution (see `regime_detector.py`'s
+        `fit_regimes`)."""
         det = MarketRegimeDetector(method="kmeans", n_regimes=3, lookback_period=50)
         det.fit_regimes(pd.DataFrame({"close": np.linspace(100, 110, 60)}))
         assert det.is_fitted
+        assert det.method == "threshold"
         # Too few valid windows to fit -- estimator stays unfitted.
         assert det.model is not None
         assert not hasattr(det.model, "cluster_centers_")
+
+        # Both regime detection and probability reporting must now consistently use the
+        # rule-based threshold path, and probabilities must be an honest one-hot -- never the
+        # old fabricated uniform distribution.
+        data = pd.DataFrame({"close": np.linspace(100, 110, 60)})
+        regime = det.detect_current_regime(data)
+        probs = det.get_regime_probabilities(data)
+        assert probs.shape == (3,)
+        assert probs.sum() == pytest.approx(1.0)
+        assert probs[regime] == pytest.approx(1.0)
+        assert not np.allclose(probs, 1 / 3)
+
+
+class TestRegimeProbabilities:
+    """Regression tests for the uniform-probability defect: `get_regime_probabilities` must
+    return the fitted model's real posterior when genuinely available, and an honest one-hot
+    (never a fabricated uniform distribution) otherwise."""
+
+    @staticmethod
+    def _well_separated_series(
+        n_per_segment: int = 200, seed: int = 11
+    ) -> pd.DataFrame:
+        """Repeated bull/bear/sideways legs -- enough data (>= the 60-sample fit minimum for
+        `n_regimes=3`) and clearly distinct regimes for the fitted model to express real,
+        confident, non-uniform posteriors rather than a degenerate/insufficient-data fit."""
+        rng = np.random.default_rng(seed)
+        segments = []
+        for _ in range(3):
+            bull = np.cumprod(1 + rng.normal(0.004, 0.008, n_per_segment))
+            bear = np.cumprod(1 + rng.normal(-0.004, 0.02, n_per_segment))
+            sideways = np.cumprod(1 + rng.normal(0.0, 0.005, n_per_segment))
+            segments.extend([bull, bear, sideways])
+        close = 100 * np.concatenate(segments)
+        return pd.DataFrame(
+            {
+                "close": close,
+                "high": close * 1.01,
+                "low": close * 0.99,
+                "volume": rng.integers(1_000_000, 5_000_000, len(close)),
+            }
+        )
+
+    def test_well_separated_regimes_produce_non_uniform_probabilities(self):
+        data = self._well_separated_series()
+        det = MarketRegimeDetector(method="hmm", n_regimes=3, lookback_period=50)
+        det.fit_regimes(data)
+        assert det.is_fitted and det.method == "hmm"
+
+        window = data.iloc[-51:]
+        regime = det.detect_current_regime(window)
+        probs = det.get_regime_probabilities(window)
+
+        assert probs.shape == (3,)
+        assert probs.sum() == pytest.approx(1.0)
+        assert not np.allclose(probs, 1 / 3)
+        # The assigned regime must be the model's own highest-probability component.
+        assert int(np.argmax(probs)) == regime
+
+    def test_hmm_method_is_gaussian_mixture_not_hidden_markov_model(self):
+        """Locks in the naming decision: `"hmm"` is documented as -- and actually
+        instantiates -- `sklearn.mixture.GaussianMixture`, kept for backward compatibility
+        rather than a real Hidden Markov Model."""
+        det = MarketRegimeDetector(method="hmm", n_regimes=3, lookback_period=50)
+        assert type(det.model).__name__ == "GaussianMixture"
+
+    def test_probability_lookup_failure_falls_back_to_one_hot_not_uniform(self):
+        """If computing real probabilities raises for any reason after a genuine fit, the
+        fallback must be an honest one-hot tied to the actual classification decision -- never
+        the previous `np.ones(n) / n` fabrication."""
+        data = self._well_separated_series()
+        det = MarketRegimeDetector(method="hmm", n_regimes=3, lookback_period=50)
+        det.fit_regimes(data)
+        assert det.is_fitted
+
+        def _boom(_features):
+            raise RuntimeError("simulated scaler failure")
+
+        det.scaler.transform = _boom
+        window = data.iloc[-51:]
+        regime = det.detect_current_regime(window)
+        probs = det.get_regime_probabilities(window)
+
+        assert probs.sum() == pytest.approx(1.0)
+        assert probs[regime] == pytest.approx(1.0)
+        assert not np.allclose(probs, 1 / 3)
 
 
 class TestRegimeAwareStrategy:

--- a/tests/backtesting/test_ml_regime_aware.py
+++ b/tests/backtesting/test_ml_regime_aware.py
@@ -166,7 +166,9 @@ class TestRegimeProbabilities:
 
     def test_well_separated_regimes_produce_non_uniform_probabilities(self):
         data = self._well_separated_series()
-        det = MarketRegimeDetector(method="hmm", n_regimes=3, lookback_period=50)
+        det = MarketRegimeDetector(
+            method="hmm", n_regimes=3, lookback_period=50, random_state=0
+        )
         det.fit_regimes(data)
         assert det.is_fitted and det.method == "hmm"
 
@@ -193,7 +195,9 @@ class TestRegimeProbabilities:
         actual classification decision -- never the previous `np.ones(n) / n`
         fabrication."""
         data = self._well_separated_series()
-        det = MarketRegimeDetector(method="hmm", n_regimes=3, lookback_period=50)
+        det = MarketRegimeDetector(
+            method="hmm", n_regimes=3, lookback_period=50, random_state=0
+        )
         det.fit_regimes(data)
         assert det.is_fitted
 

--- a/tests/backtesting/test_service.py
+++ b/tests/backtesting/test_service.py
@@ -438,6 +438,26 @@ async def test_analyze_market_regimes_rejects_insufficient_data():
         await service.analyze_market_regimes("AAPL", lookback_period=50)
 
 
+async def test_analyze_market_regimes_reports_actual_fallback_method():
+    """Regression test: with enough data to pass the tool's own minimum-data guard but not
+    enough to clear `MarketRegimeDetector`'s internal fit-sample threshold, the detector
+    silently falls back to the rule-based "threshold" method. The reported `method` field must
+    reflect that actual fallback, not the originally-requested "hmm"/"kmeans" -- previously it
+    always echoed the request, misrepresenting what was actually used."""
+    service = _service(StubMarketData(_make_ohlcv(150)))
+
+    result = await service.analyze_market_regimes(
+        "AAPL", method="hmm", lookback_period=50
+    )
+
+    assert result.method == "threshold"
+    # Every probability entry must be an honest one-hot (sums to 1, one entry is 1.0), never
+    # the previous fabricated uniform [1/3, 1/3, 1/3].
+    for entry in result.recent_regime_history:
+        assert sum(entry.probabilities) == pytest.approx(1.0)
+        assert max(entry.probabilities) == pytest.approx(1.0)
+
+
 # ---------------------------------------------------------------------------
 # 11. create_strategy_ensemble
 # ---------------------------------------------------------------------------

--- a/tests/backtesting/test_service.py
+++ b/tests/backtesting/test_service.py
@@ -439,10 +439,11 @@ async def test_analyze_market_regimes_rejects_insufficient_data():
 
 
 async def test_analyze_market_regimes_reports_actual_fallback_method():
-    """Regression test: with enough data to pass the tool's own minimum-data guard but not
-    enough to clear `MarketRegimeDetector`'s internal fit-sample threshold, the detector
-    silently falls back to the rule-based "threshold" method. The reported `method` field must
-    reflect that actual fallback, not the originally-requested "hmm"/"kmeans" -- previously it
+    """Regression test: with enough data to pass the tool's own minimum-data
+    guard but not enough to clear `MarketRegimeDetector`'s internal
+    fit-sample threshold, the detector silently falls back to the rule-based
+    "threshold" method. The reported `method` field must reflect that actual
+    fallback, not the originally-requested "hmm"/"kmeans" -- previously it
     always echoed the request, misrepresenting what was actually used."""
     service = _service(StubMarketData(_make_ohlcv(150)))
 
@@ -451,11 +452,14 @@ async def test_analyze_market_regimes_reports_actual_fallback_method():
     )
 
     assert result.method == "threshold"
-    # Every probability entry must be an honest one-hot (sums to 1, one entry is 1.0), never
-    # the previous fabricated uniform [1/3, 1/3, 1/3].
+    # Every probability entry must be the exact one-hot vector at its own
+    # `regime` -- never the previous fabricated uniform [1/3, 1/3, 1/3], and
+    # not merely "sums to 1 with a max of 1" (which a non-one-hot vector
+    # could also satisfy).
     for entry in result.recent_regime_history:
-        assert sum(entry.probabilities) == pytest.approx(1.0)
-        assert max(entry.probabilities) == pytest.approx(1.0)
+        expected = [0.0, 0.0, 0.0]
+        expected[entry.regime] = 1.0
+        assert entry.probabilities == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📋 Pull Request Summary

**Brief description of changes:**
Fixes `backtesting_analyze_market_regimes`'s silent fit-state dishonesty: it could report `method: "hmm"`/`"kmeans"` and a fabricated uniform probability distribution while actually running entirely on the rule-based threshold classifier.

**Related issue(s):**
- Fixes #247

## 💰 Financial Disclaimer Acknowledgment

- [x] I understand this is educational software and not financial advice
- [x] Any financial analysis features include appropriate disclaimers
- [x] This PR maintains the educational/personal-use focus of the project

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements to documentation)
- [ ] 🔧 Refactor (code changes that neither fix bugs nor add features)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (dependencies, build tools, etc.)

## 🎯 Component Areas

**Primary areas affected:**
- [ ] Data fetching (Tiingo, Yahoo Finance, FRED)
- [ ] Technical analysis calculations
- [ ] Stock screening strategies
- [ ] Portfolio analysis and optimization
- [x] MCP server/tools implementation (backtesting domain)
- [ ] Database operations and models
- [ ] Caching (Redis/in-memory)
- [ ] Claude Desktop integration
- [ ] Development tools and setup
- [x] Documentation and examples

## 🔧 Implementation Details

**Technical approach:**
`MarketRegimeDetector.fit_regimes` has several "not enough data" early-return branches (e.g. fewer than `max(50, n_regimes*20)` valid feature windows -- which this tool's own default 365-day lookback usually doesn't clear for `n_regimes=3`). Each of these set `self.is_fitted = True` without ever fitting `self.scaler`/`self.model`. `get_regime_probabilities` then hit `self.scaler.transform(...)`, raised `NotFittedError` on the never-fitted scaler, and its broad `except` fabricated `np.ones(n) / n`. Independently, `detect_current_regime` fell back to the rule-based threshold classifier through its own, separately-triggered exception handling -- so the regime label varied plausibly while the probability stayed fake-uniform, and `self.method` was never updated.

**Key changes:**
- Every "can't fit a genuine statistical model" branch in `fit_regimes` (four early-return conditions plus two exception handlers) now converges on one explicit state already used for an explicit `method="threshold"` request: `self.method = "threshold"; self.is_fitted = True`.
- `get_regime_probabilities` now returns the fitted model's real `predict_proba` posterior when genuinely available, or an honest one-hot vector at the actually-assigned regime -- the fabricated-uniform return path is removed entirely.
- `analyze_market_regimes` now reports `detector.method` (what was actually used) instead of the original request.
- `method="hmm"` remains an accepted, backward-compatible input value; docstrings now state clearly it fits `sklearn.mixture.GaussianMixture` (no transition/temporal modeling), not a real Hidden Markov Model. No new dependency introduced.
- Found via CodeRabbit review on this PR: `_one_hot_via_threshold_fallback` indexed `probs[regime]` without checking it against `self.n_regimes`. `detect_regime_threshold` always returns one of exactly three hardcoded labels (0/1/2), so a detector configured with `n_regimes < 3` could raise `IndexError`. The label is now clamped into `[0, n_regimes)` before indexing.
- Also from CodeRabbit review: tightened a regression test that only checked `sum()==1`/`max()==1` on returned probabilities (which a non-one-hot vector could also satisfy) to compare the exact expected one-hot vector.

**Dependencies:**
- [x] No new dependencies added

## 🧪 Testing

**Testing performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (live MCP tool calls: default-lookback AAPL confirming honest `"threshold"` fallback + one-hot output; ~3.5-year lookback confirming a genuine `"hmm"` fit with real non-uniform posteriors)
- [ ] Tested with Claude Desktop
- [ ] Tested with different data sources
- [ ] Performance testing completed

**Test scenarios covered:**
- [x] Happy path functionality (genuine model fit on well-separated synthetic regimes)
- [x] Error handling and edge cases (insufficient data, runtime failure after a genuine fit, `n_regimes < 3`)
- [ ] Data validation and sanitization
- [ ] API rate limiting compliance
- [ ] Database operations
- [ ] Cache behavior

**Manual testing:**
```bash
uv run pytest tests/backtesting/ tests/server/
uv run --extra dev ruff check .
uv run --extra dev ruff format --check .
uv run lint-imports
uv run python tools/check_docs_catalog.py
```
Result: 245 passed, 5 skipped (pre-existing, Research-extra-gated), 0 failed. `lint-imports`: 14/14 contracts kept. `ruff check`/`ruff format --check`: clean. Docs catalog check: passed.

`make typecheck` could not be verified in this environment: it requires `--extra research` to resolve `maverick.backtesting.strategies.parser`'s lazy BYOK-LLM import (a pre-existing condition unrelated to this PR -- `parser.py` is untouched by this diff), and this environment does not install the `[research]` extra. Not claiming this check as passed.

## 📊 Financial Analysis Impact

**Financial calculations:**
- [ ] No financial calculations affected
- [ ] New financial calculations added (validated for accuracy)
- [x] Existing calculations modified (thoroughly tested)
- [x] All calculations include appropriate disclaimers

**Data providers:**
- [x] No data provider changes

**Market data handling:**
- [ ] Historical data processing
- [ ] Real-time data integration
- [x] Technical indicator calculations (regime classification confidence reporting)
- [ ] Screening algorithm changes

## 🔒 Security Considerations

**Security checklist:**
- [x] No hardcoded secrets or credentials
- [x] Input validation implemented (regime index now bounds-checked against `n_regimes`)
- [x] Error handling doesn't leak sensitive information
- [x] API keys handled securely via environment variables (unaffected)
- [x] SQL injection prevention verified (not applicable -- no SQL in this path)
- [x] Rate limiting respected for external APIs (unaffected)

## 📚 Documentation

**Documentation updates:**
- [x] Code comments added/updated
- [ ] README.md updated (if needed)
- [x] API documentation updated (`docs/api/backtesting.md`)
- [ ] Examples/tutorials added
- [x] Financial disclaimers included where appropriate

**Breaking changes documentation:**
- [x] No breaking changes (return shape unchanged; `method`/`probabilities` values become honest rather than fabricated)

## ✅ Pre-submission Checklist

**Code quality:**
- [x] Code follows the project style guide
- [x] Self-review of code completed
- [x] Tests added/updated and passing
- [x] No linting errors (`make lint` -- verified via `ruff check`/`ruff format --check`/`lint-imports`)
- [ ] Type checking passes (`make typecheck`) -- not run in this environment; see Testing section
- [x] All tests pass (`make test`)

**Financial software standards:**
- [x] Financial disclaimers included where appropriate
- [x] No investment advice or guarantees provided
- [x] Educational purpose maintained
- [x] Data accuracy considerations documented
- [x] Risk warnings included for relevant features

**Community standards:**
- [x] PR title is descriptive and follows convention
- [x] Description clearly explains the changes
- [x] Related issues are linked
- [ ] Screenshots/examples included (if applicable) -- not applicable, backend logic fix with no UI
- [x] Ready for review

## 🤝 Review Guidance

**Areas needing special attention:**
- A real Hidden Markov Model implementation is intentionally out of scope for this fix (no new heavy dependency); `method="hmm"` stays a documented misnomer for `GaussianMixture`, kept for backward compatibility.
- `detect_regime_threshold`'s hardcoded 3-way (0/1/2) output regardless of `n_regimes` is pre-existing legacy behavior; this PR only guards the one new call site (`_one_hot_via_threshold_fallback`) against indexing out of bounds, it does not redesign the threshold classifier itself.

## 🚀 Deployment Notes

**Environment considerations:**
- [x] No environment changes required

**Rollback plan:**
- [x] Changes are fully backward compatible

## 🎓 Educational Impact

**Learning value:**
Demonstrates how two independent, differently-triggered silent fallbacks for the same underlying condition can drift apart (one producing plausible-looking output, the other fabricating confidence) unless the fit-state itself is made the single source of truth.

---

**Additional Notes:**

## Tests added

- `test_well_separated_regimes_produce_non_uniform_probabilities`
- `test_hmm_method_is_gaussian_mixture_not_hidden_markov_model`
- `test_probability_lookup_failure_falls_back_to_one_hot_not_uniform`
- `test_threshold_fallback_does_not_index_error_with_fewer_than_three_regimes` (added for the CodeRabbit-found bounds issue)
- `test_analyze_market_regimes_reports_actual_fallback_method`
- Updated `test_insufficient_data_falls_back_to_threshold` to assert the new honest `is_fitted=True, method="threshold"` state
