### PR TITLE
test(research): isolate research tests from the developer environment

### DIFF
--- a/tests/research/conftest.py
+++ b/tests/research/conftest.py
@@ -19,6 +19,13 @@ singleton: `DeepResearchAgent.__init__` calls `get_llm()` when no `llm` is
 injected, and `tests/research/test_agents_graph.py` exercises that
 not-configured path (no `LLM_PROVIDER` env set) alongside other tests that
 may set BYOK env vars via `monkeypatch`.
+
+As of 2026-09-05, also scrubs the research and BYOK environment variables
+before every test. A developer shell that exports a real `EXA_API_KEY`
+silently satisfied the "Exa not configured" precondition in
+`test_service.py`, so the service built a real agent and the unit test made
+live Exa and LLM calls. Tests that need a variable set it themselves through
+`monkeypatch` after this fixture runs.
 """
 
 import pytest
@@ -28,9 +35,22 @@ from maverick.platform.http import reset_breakers
 from maverick.platform.llm import reset_llm_settings
 from maverick.research.config import reset_research_settings
 
+_ENV_VARS_TO_SCRUB = (
+    "EXA_API_KEY",
+    "RESEARCH_SEARCH_BACKEND",
+    "SEARXNG_BASE_URL",
+    "LLM_PROVIDER",
+    "LLM_API_KEY",
+    "LLM_MODEL",
+    "LLM_BASE_URL",
+    "LLM_TEMPERATURE",
+)
+
 
 @pytest.fixture(autouse=True)
-def _reset_research_process_state():
+def _reset_research_process_state(monkeypatch: pytest.MonkeyPatch):
+    for name in _ENV_VARS_TO_SCRUB:
+        monkeypatch.delenv(name, raising=False)
     reset_breakers()
     reset_market_data_settings()
     reset_research_settings()


### PR DESCRIPTION
A developer shell that exports a real `EXA_API_KEY` silently satisfied the "Exa not configured" precondition in `tests/research/test_service.py`, so the service built a real agent and a unit test made live Exa and LLM calls (found while running the local gate for #242; CI has no key and was unaffected). The research conftest's autouse fixture now scrubs the research and BYOK variables before every test; tests that need one set it through `monkeypatch` afterwards. Verified: the research suite passes with the key exported in the shell.

https://claude.ai/code/session_01SQFYuZqoU2U7CoML32cf2L