### PR TITLE
build: migrate to FastMCP 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![FastMCP](https://img.shields.io/badge/FastMCP-3-green.svg)](https://github.com/jlowin/fastmcp)
+[![FastMCP](https://img.shields.io/badge/FastMCP-4-green.svg)](https://github.com/jlowin/fastmcp)
 [![GitHub Stars](https://img.shields.io/github/stars/wshobson/maverick-mcp?style=social)](https://github.com/wshobson/maverick-mcp)
 [![GitHub Issues](https://img.shields.io/github/issues/wshobson/maverick-mcp)](https://github.com/wshobson/maverick-mcp/issues)
 [![GitHub Forks](https://img.shields.io/github/forks/wshobson/maverick-mcp?style=social)](https://github.com/wshobson/maverick-mcp/network/members)

--- a/docs/runbooks/mcp-clients.md
+++ b/docs/runbooks/mcp-clients.md
@@ -27,6 +27,15 @@ process, or when you are connecting from somewhere other than this machine.
 > Requesting `/mcp/` returns a `307` redirect to `/mcp`, and clients that do
 > not follow redirects on `POST` will fail to register tools.
 
+> [!NOTE]
+> Protocol revisions (FastMCP 4 on the MCP Python SDK 2.x): the HTTP
+> transport serves both the sessionless `2026-07-28` revision and the
+> `2025-11-25` handshake revision, negotiated per connection. The STDIO
+> transport serves the handshake revision only; the SDK answers a
+> `2026-07-28` request on stdio with "this connection serves the handshake
+> protocol era". Clients built on the official SDKs negotiate this
+> automatically.
+
 ## Endpoint And Binding
 
 ```bash

--- a/maverick/backtesting/tools_support.py
+++ b/maverick/backtesting/tools_support.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-READ_ONLY_ANNOTATIONS = {"readOnlyHint": True}
+READ_ONLY_ANNOTATIONS = {"read_only_hint": True}
 
 _service: BacktestingService | None = None
 

--- a/maverick/market_data/tools.py
+++ b/maverick/market_data/tools.py
@@ -9,11 +9,11 @@ from fastmcp import FastMCP
 
 from maverick.market_data.service import MarketDataService
 
-_READ_ONLY_ANNOTATIONS = {"readOnlyHint": True}
+_READ_ONLY_ANNOTATIONS = {"read_only_hint": True}
 _CLEAR_CACHE_ANNOTATIONS = {
-    "readOnlyHint": False,
-    "destructiveHint": False,
-    "idempotentHint": True,
+    "read_only_hint": False,
+    "destructive_hint": False,
+    "idempotent_hint": True,
 }
 
 _service: MarketDataService | None = None

--- a/maverick/portfolio/tools.py
+++ b/maverick/portfolio/tools.py
@@ -17,29 +17,29 @@ from maverick.portfolio.tools_journal import (
     portfolio_journal_review,
 )
 
-_READ_ONLY_ANNOTATIONS = {"readOnlyHint": True}
+_READ_ONLY_ANNOTATIONS = {"read_only_hint": True}
 _ADD_ANNOTATIONS = {
-    "readOnlyHint": False,
-    "destructiveHint": False,
-    "idempotentHint": False,
+    "read_only_hint": False,
+    "destructive_hint": False,
+    "idempotent_hint": False,
 }
 _REMOVE_ANNOTATIONS = {
-    "readOnlyHint": False,
-    "destructiveHint": True,
-    "idempotentHint": False,
+    "read_only_hint": False,
+    "destructive_hint": True,
+    "idempotent_hint": False,
 }
 _CLEAR_ANNOTATIONS = {
-    "readOnlyHint": False,
-    "destructiveHint": True,
-    "idempotentHint": True,
+    "read_only_hint": False,
+    "destructive_hint": True,
+    "idempotent_hint": True,
 }
 # A watchlist remove deletes every matching row in one call, so repeat calls
 # for the same (watchlist_id, symbol) are a no-op after the first --
 # idempotent, unlike partial-shares `portfolio_remove_position`.
 _WATCHLIST_REMOVE_ANNOTATIONS = {
-    "readOnlyHint": False,
-    "destructiveHint": True,
-    "idempotentHint": True,
+    "read_only_hint": False,
+    "destructive_hint": True,
+    "idempotent_hint": True,
 }
 
 _service: PortfolioService | None = None

--- a/maverick/research/tools.py
+++ b/maverick/research/tools.py
@@ -48,7 +48,7 @@ __all__ = ["configure", "register"]
 
 logger = logging.getLogger(__name__)
 
-_ANNOTATIONS = {"readOnlyHint": True, "openWorldHint": True}
+_ANNOTATIONS = {"read_only_hint": True, "open_world_hint": True}
 
 _service: ResearchService | None = None
 

--- a/maverick/screening/tools.py
+++ b/maverick/screening/tools.py
@@ -7,11 +7,11 @@ from fastmcp import FastMCP
 from maverick.screening.service import ScreeningService
 from maverick.screening.types import ScreeningCriteria, ScreeningResult, ScreenName
 
-_READ_ONLY_ANNOTATIONS = {"readOnlyHint": True}
+_READ_ONLY_ANNOTATIONS = {"read_only_hint": True}
 _RUN_SCREENS_ANNOTATIONS = {
-    "readOnlyHint": False,
-    "destructiveHint": False,
-    "idempotentHint": True,
+    "read_only_hint": False,
+    "destructive_hint": False,
+    "idempotent_hint": True,
 }
 
 _service: ScreeningService | None = None

--- a/maverick/technical/tools.py
+++ b/maverick/technical/tools.py
@@ -6,7 +6,7 @@ from fastmcp import FastMCP
 
 from maverick.technical.service import TechnicalService
 
-_READ_ONLY_ANNOTATIONS = {"readOnlyHint": True}
+_READ_ONLY_ANNOTATIONS = {"read_only_hint": True}
 
 _service: TechnicalService | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,11 @@ description = "Personal-use MCP server for Claude Desktop providing professional
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    # Core MCP and server dependencies
-    "fastmcp>=3.3.1",
-    "mcp>=1.28.1",
+    # Core MCP and server dependencies. FastMCP 4 owns the MCP SDK version
+    # (no direct `mcp` pin: nothing here imports it). FastMCP 4 no longer
+    # depends on httpx, and maverick/platform/http.py imports it directly,
+    # so the httpx pin below is load-bearing.
+    "fastmcp>=4.0.3",
     "uvicorn>=0.48.0",
     "python-multipart>=0.0.31",
     "aiofiles>=25.1.0",

--- a/tests/backtesting/test_tools.py
+++ b/tests/backtesting/test_tools.py
@@ -635,7 +635,7 @@ async def test_register_marks_every_tool_read_only(stub_service):
     for name in _EXPECTED_TOOL_NAMES:
         tool = await mcp.get_tool(name)
         assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.read_only_hint is True
 
 
 async def test_register_in_memory_client_round_trips_list_strategies(stub_service):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,16 @@ at the Phase 8 cutover. None of the surviving domain trees
 is kept only as the collection root; nothing in it is required for the
 surviving suites.
 """
+
+import fastmcp
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _camelcase_bridge_off():
+    """FastMCP 4 bridges camelCase reads of MCP SDK v2 models (`readOnlyHint`
+    for `read_only_hint`) with a deprecation warning. Run the suite with the
+    bridge off so any stale camelCase read fails as an `AttributeError` now,
+    before FastMCP removes the shim."""
+    fastmcp.settings.mcp_camelcase_compat = False
+    yield

--- a/tests/market_data/test_tools.py
+++ b/tests/market_data/test_tools.py
@@ -434,7 +434,7 @@ async def test_register_marks_all_but_clear_cache_read_only(stub_service):
     for name in _EXPECTED_TOOL_NAMES - {"market_data_clear_market_cache"}:
         tool = await mcp.get_tool(name)
         assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.read_only_hint is True
 
 
 async def test_register_marks_clear_cache_honestly_non_read_only(stub_service):
@@ -444,9 +444,9 @@ async def test_register_marks_clear_cache_honestly_non_read_only(stub_service):
     tool = await mcp.get_tool("market_data_clear_market_cache")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.idempotentHint is True
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.idempotent_hint is True
 
 
 async def test_register_in_memory_client_round_trips_get_quote(stub_service):

--- a/tests/portfolio/test_tools.py
+++ b/tests/portfolio/test_tools.py
@@ -1260,7 +1260,7 @@ async def test_register_marks_reads_read_only(stub_service):
     for name in _READ_ONLY_NAMES:
         tool = await mcp.get_tool(name)
         assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.read_only_hint is True
 
 
 async def test_register_marks_add_honestly(stub_service):
@@ -1270,9 +1270,9 @@ async def test_register_marks_add_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_add_position")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.idempotentHint is False
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.idempotent_hint is False
 
 
 async def test_register_marks_remove_honestly(stub_service):
@@ -1282,9 +1282,9 @@ async def test_register_marks_remove_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_remove_position")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is True
-    assert tool.annotations.idempotentHint is False
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is True
+    assert tool.annotations.idempotent_hint is False
 
 
 async def test_register_marks_clear_honestly(stub_service):
@@ -1294,9 +1294,9 @@ async def test_register_marks_clear_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_clear_portfolio")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is True
-    assert tool.annotations.idempotentHint is True
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is True
+    assert tool.annotations.idempotent_hint is True
 
 
 async def test_register_marks_watchlist_create_honestly(stub_service):
@@ -1306,9 +1306,9 @@ async def test_register_marks_watchlist_create_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_watchlist_create")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.idempotentHint is False
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.idempotent_hint is False
 
 
 async def test_register_marks_watchlist_add_honestly(stub_service):
@@ -1318,9 +1318,9 @@ async def test_register_marks_watchlist_add_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_watchlist_add")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.idempotentHint is False
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.idempotent_hint is False
 
 
 async def test_register_marks_watchlist_remove_honestly(stub_service):
@@ -1330,9 +1330,9 @@ async def test_register_marks_watchlist_remove_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_watchlist_remove")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is True
-    assert tool.annotations.idempotentHint is True
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is True
+    assert tool.annotations.idempotent_hint is True
 
 
 async def test_register_marks_journal_add_trade_honestly(stub_service):
@@ -1342,9 +1342,9 @@ async def test_register_marks_journal_add_trade_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_journal_add_trade")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.idempotentHint is False
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.idempotent_hint is False
 
 
 async def test_register_marks_journal_close_trade_honestly(stub_service):
@@ -1354,9 +1354,9 @@ async def test_register_marks_journal_close_trade_honestly(stub_service):
     tool = await mcp.get_tool("portfolio_journal_close_trade")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.idempotentHint is False
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.idempotent_hint is False
 
 
 async def test_register_attaches_my_holdings_resource(stub_service):

--- a/tests/research/test_tools.py
+++ b/tests/research/test_tools.py
@@ -186,8 +186,8 @@ async def test_register_marks_every_tool_read_only_and_open_world(stub_service):
     for name in _EXPECTED_TOOL_NAMES:
         tool = await mcp.get_tool(name)
         assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is True
-        assert tool.annotations.openWorldHint is True
+        assert tool.annotations.read_only_hint is True
+        assert tool.annotations.open_world_hint is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/screening/test_tools.py
+++ b/tests/screening/test_tools.py
@@ -310,7 +310,7 @@ async def test_register_marks_all_but_run_screens_read_only(stub_service):
     for name in _EXPECTED_TOOL_NAMES - {"screening_run_screens"}:
         tool = await mcp.get_tool(name)
         assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.read_only_hint is True
 
 
 async def test_register_marks_run_screens_honestly_non_read_only(stub_service):
@@ -320,9 +320,9 @@ async def test_register_marks_run_screens_honestly_non_read_only(stub_service):
     tool = await mcp.get_tool("screening_run_screens")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is False
-    assert tool.annotations.idempotentHint is True
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.idempotent_hint is True
 
 
 async def test_register_in_memory_client_round_trips_get_bullish(stub_service):

--- a/tests/server/test_assembly.py
+++ b/tests/server/test_assembly.py
@@ -200,3 +200,16 @@ class TestSmokeRoundTrip:
         assert payload["status"] == "success"
         assert payload["ticker"] == "AAPL"
         assert "trading_view" in payload["charts"]
+
+
+async def test_tool_annotations_serialize_camel_case_on_the_wire():
+    """Annotations are declared with SDK v2 snake_case field names; the MCP wire
+    format is camelCase. Pin both sides so a future rename cannot drop the hint."""
+    mcp = build_server()
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+    tool = tools["market_data_get_chart_links"]
+    assert tool.annotations is not None
+    assert tool.annotations.read_only_hint is True
+    wire = tool.annotations.model_dump(by_alias=True, exclude_none=True)
+    assert wire["readOnlyHint"] is True

--- a/tests/technical/test_tools.py
+++ b/tests/technical/test_tools.py
@@ -311,7 +311,7 @@ async def test_register_marks_every_tool_read_only(stub_service):
     for name in _EXPECTED_TOOL_NAMES:
         tool = await mcp.get_tool(name)
         assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.read_only_hint is True
 
 
 async def test_register_in_memory_client_round_trips_get_rsi(stub_service):

--- a/uv.lock
+++ b/uv.lock
@@ -964,21 +964,22 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.3.1"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1a/bee10aff530338f3b8982a3dd1c377c3ba5d0bc724615bf358422c4e9ecf/fastmcp-4.0.3.tar.gz", hash = "sha256:0dd50baf070105ee4436c245f087ac3c047e655c32d9e783de16d0bf15783a98", size = 42311418, upload-time = "2026-09-05T00:31:36.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/66600db497b3be21cf141f01296308169859d48ed9b1bc8ba7c9d83279b7/fastmcp-4.0.3-py3-none-any.whl", hash = "sha256:f743f43193e1daf606e6497a9dddba5bbaad7df7957a98fd093716ecf4458b99", size = 8076, upload-time = "2026-09-05T00:31:33.957Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.3.1"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -986,26 +987,28 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a9/b7b796b0d4a5e095dadef233833c82ac1136f5c110dd9947b2e9a4988518/fastmcp_slim-4.0.3.tar.gz", hash = "sha256:3ce04a82b82cc41ccb12bb3bb366cfd65b52bc797b8fee332a75da9d480f9b74", size = 685704, upload-time = "2026-09-05T00:31:12.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4b/6b31820d87f56d5773538860878c8634b618cd1e9044b3bfbd8a78380a0f/fastmcp_slim-4.0.3-py3-none-any.whl", hash = "sha256:3756ed4bd9f82f40adaf51974b7cdd1463ab6b9f479cf69b69b2692969312b87", size = 859717, upload-time = "2026-09-05T00:31:10.93Z" },
 ]
 
 [package.optional-dependencies]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
 server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
@@ -1016,6 +1019,7 @@ server = [
     { name = "pyperclip" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -2384,7 +2388,6 @@ dependencies = [
     { name = "greenlet" },
     { name = "hiredis" },
     { name = "httpx" },
-    { name = "mcp" },
     { name = "msgpack" },
     { name = "numpy" },
     { name = "openai" },
@@ -2454,7 +2457,7 @@ requires-dist = [
     { name = "certifi", specifier = ">=2026.5.20" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "exa-py", marker = "extra == 'research'", specifier = ">=2.13.0" },
-    { name = "fastmcp", specifier = ">=3.3.1" },
+    { name = "fastmcp", specifier = ">=4.0.3" },
     { name = "finvizfinance", specifier = ">=1.3.0" },
     { name = "greenlet", specifier = ">=3.5.1" },
     { name = "greenlet", marker = "extra == 'dev'", specifier = ">=3.5.1" },
@@ -2465,7 +2468,6 @@ requires-dist = [
     { name = "langchain-community", marker = "extra == 'research'", specifier = ">=0.4.2" },
     { name = "langchain-openai", marker = "extra == 'research'", specifier = ">=1.3.5" },
     { name = "langgraph", marker = "extra == 'research'", specifier = ">=1.2.11" },
-    { name = "mcp", specifier = ">=1.28.1" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "numba", marker = "extra == 'backtesting'", specifier = ">=0.61.2" },
     { name = "numpy", specifier = ">=2.2.6" },
@@ -2506,15 +2508,15 @@ dev = [{ name = "import-linter", specifier = ">=2.13" }]
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -2524,9 +2526,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -4565,11 +4580,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves the server to FastMCP 4 (MCP Python SDK v2), which serves the 2026-07-28 protocol revision over HTTP alongside 2025-11-25, and unblocks #235. Supersedes #249, whose lock bump pulled the major upgrade in silently.

- `fastmcp>=4.0.3`; the direct `mcp` pin is gone (nothing imported it); `httpx` stays pinned directly because the platform HTTP seam imports it and FastMCP 4 no longer depends on it. The one `except httpx.TransportError` in `maverick/platform/http.py` guards our own outbound client, not anything handed to FastMCP, so the httpx2 checklist item does not apply.
- Tool annotations are declared with SDK v2 snake_case field names; the wire format stays camelCase (pinned by a new assembly test). The suite runs with the camelCase compatibility bridge off, which is how the remaining camelCase reads in six test modules were found.
- Upgrade-guide checklist: no removed or changed API in use. Stdio and HTTP smoke tests pass (52 tools, 3 prompts, 1 resource); `/mcp/` still answers 307.
- Conformance (`@hasmcp/mcp-spec-test` 0.1.5, run with `uv run --directory`): 2025-11-25 conformant on stdio and HTTP; 2026-07-28 over HTTP 31 passed with two residual SDK transport-layer failures; stdio serves the handshake era only. Full reports and the residual list are on #235. FastMCP 3 failed the 2025-11-25 `CallToolResult` content check that this fixes (#234).
- Runbook note on which revisions each transport serves; README badge.

https://claude.ai/code/session_01SQFYuZqoU2U7CoML32cf2L
