### PR TITLE
feat(research): self-hosted SearXNG search backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ DATABASE_URL=sqlite:///maverick.db
 # ---------------------------------------------------------------------------
 # Get a key at https://exa.ai (free tier available)
 # EXA_API_KEY=your_exa_api_key_here
+# Or point research at a self-hosted SearXNG instance instead of Exa (no key).
+# The instance must serve JSON: settings.yml -> search: formats: [html, json]
+# RESEARCH_SEARCH_BACKEND=exa  # exa | searxng
+# SEARXNG_BASE_URL=http://localhost:8080
 
 # ---------------------------------------------------------------------------
 # Market data (maverick/market_data/config.py) - optional; core quotes/history

--- a/README.md
+++ b/README.md
@@ -489,7 +489,9 @@ Absent the extra, the server still boots and registers zero
 | `research_analyze_company` | Comprehensive research on a specific company. |
 | `research_analyze_sentiment` | Market sentiment analysis for a topic or sector. |
 
-Requires `EXA_API_KEY` (web search) plus a configured BYOK LLM
+Requires a search backend (`EXA_API_KEY` for Exa, the default, or
+`RESEARCH_SEARCH_BACKEND=searxng` plus `SEARXNG_BASE_URL` for a self-hosted
+SearXNG instance) and a configured BYOK LLM
 (`LLM_PROVIDER`/`LLM_API_KEY`/`LLM_MODEL`; see [Configuration](#configuration)).
 Install with `uv sync --extra research` or
 `pip install "maverick-mcp-server[research]"`. Absent the extra, the server
@@ -529,6 +531,8 @@ No API key is required to run the core server; stock data comes from `yfinance`.
 - `LLM_BASE_URL` - Base URL override, required when `LLM_PROVIDER=openai_compatible`.
 - `LLM_TEMPERATURE` - Sampling temperature (default: `0.0`).
 - `EXA_API_KEY` - Web search for the research tools (get at [exa.ai](https://exa.ai)).
+- `RESEARCH_SEARCH_BACKEND` - `exa` (default) or `searxng`.
+- `SEARXNG_BASE_URL` - Base URL of a self-hosted SearXNG instance with the JSON format enabled; used when the backend is `searxng`.
 
 Migrating an older `.env` (legacy `OPENROUTER_API_KEY`-style auto-detection,
 `TIINGO_API_KEY`, etc.)? See `docs/runbooks/migrating-to-v1.md`.
@@ -653,7 +657,7 @@ endpoint or `HEALTHCHECK` -- this is an MCP server, not a REST API.
 **Research Tools Not Available:**
 - Ensure the `research` extra is installed: `pip install "maverick-mcp-server[research]"`
 - Ensure `LLM_PROVIDER`, `LLM_API_KEY`, and `LLM_MODEL` are set in `.env`
-- Ensure `EXA_API_KEY` is set for web search
+- Ensure `EXA_API_KEY` is set for web search, or `RESEARCH_SEARCH_BACKEND=searxng` with `SEARXNG_BASE_URL`
 
 **Backtesting Tools Not Available:**
 - Ensure the `backtesting` extra is installed: `pip install "maverick-mcp-server[backtesting]"`

--- a/docs/features/deep-research.md
+++ b/docs/features/deep-research.md
@@ -87,18 +87,42 @@ accessed without it installed.
 
 ## Configuration
 
-Research needs two independent things configured: a search provider (Exa)
-and a BYOK LLM. Both are checked at call time; a tool call fails fast with a
+Research needs two independent things configured: a search backend (Exa by
+default, or a self-hosted SearXNG instance) and a BYOK LLM. Both are checked at call time; a tool call fails fast with a
 clear error naming exactly what to set if either is missing.
 
-### Search provider
+### Search backend
+
+The default backend is Exa:
 
 ```bash
 EXA_API_KEY=your_exa_key
 ```
 
-`EXA_API_KEY` is the sole "is research configured" gate for search -- there
-is no other search-provider key in this port.
+To use a self-hosted SearXNG instance instead, with no API key, select the
+backend and point it at the instance:
+
+```bash
+RESEARCH_SEARCH_BACKEND=searxng
+SEARXNG_BASE_URL=http://localhost:8080
+```
+
+The instance must serve the JSON API. Most SearXNG installs ship with it
+disabled; enable it in the instance's `settings.yml`:
+
+```yaml
+search:
+  formats:
+    - html
+    - json
+```
+
+A 403 from the instance is reported by the research tools with that
+instruction. SearXNG returns result snippets rather than page text, so
+`raw_content` equals `content` for its results, and the recency window
+follows `RESEARCH_DEFAULT_TIMEFRAME` (`1m` maps to SearXNG's `month`
+range). The selected backend is the one "is research configured" gate for
+search: `EXA_API_KEY` for Exa, `SEARXNG_BASE_URL` for SearXNG.
 
 ### BYOK LLM
 

--- a/maverick/research/config.py
+++ b/maverick/research/config.py
@@ -62,11 +62,15 @@ package's import reach:
   count after which `WebSearchProvider._record_failure` (`.../base.py:57-84`)
   marks a provider unhealthy -- distinct from the breaker fields above; this
   gates the provider's own `is_healthy()` flag, not `get_breaker`.
+- `search_backend` (`RESEARCH_SEARCH_BACKEND`, default `exa`) and
+  `searxng_base_url` (`SEARXNG_BASE_URL`): the 2026-09 SearXNG backend
+  selection (#186). See `providers/searxng.py`.
 """
 
 from functools import lru_cache
+from typing import Literal
 
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from maverick.platform.config import _clean_env, _env_float, _env_int, _env_str
 from maverick.research.types import ResearchDepth
@@ -84,8 +88,32 @@ def _resolve_exa_api_key() -> SecretStr | None:
     return SecretStr(value) if value is not None else None
 
 
+SearchBackend = Literal["exa", "searxng"]
+"""Which web search provider backs the research tools. `exa` needs `EXA_API_KEY`;
+`searxng` needs `SEARXNG_BASE_URL` (a self-hosted instance with the JSON format
+enabled) and no key."""
+
+
 class ResearchSettings(BaseModel):
     exa_api_key: SecretStr | None = Field(default_factory=_resolve_exa_api_key)
+    search_backend: SearchBackend = Field(
+        default_factory=lambda: _env_str("RESEARCH_SEARCH_BACKEND", "exa"),
+        validate_default=True,
+    )
+    searxng_base_url: str | None = Field(
+        default_factory=lambda: _clean_env("SEARXNG_BASE_URL"),
+        validate_default=True,
+    )
+
+    @field_validator("searxng_base_url")
+    @classmethod
+    def _normalize_searxng_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip().rstrip("/")
+        if not value.startswith(("http://", "https://")):
+            raise ValueError("SEARXNG_BASE_URL must start with http:// or https://")
+        return value
 
     default_research_depth: ResearchDepth = Field(
         default_factory=lambda: _env_str("RESEARCH_DEFAULT_DEPTH", "standard"),

--- a/maverick/research/providers/__init__.py
+++ b/maverick/research/providers/__init__.py
@@ -1,4 +1,4 @@
-"""Web search providers (`WebSearchProvider`, `ExaSearchProvider`). Third-layer sibling: imports config and types.
+"""Web search providers (`WebSearchProvider`, `ExaSearchProvider`, `SearXNGProvider`). Third-layer sibling: imports config and types.
 
 No parallel circuit-breaker manager lives here: `exa.py`'s module docstring
 records the comparison against `maverick.platform.http`'s `CircuitBreaker`/

--- a/maverick/research/providers/exa.py
+++ b/maverick/research/providers/exa.py
@@ -55,14 +55,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
 
 from maverick.platform.config import HttpSettings
 from maverick.platform.http import CircuitOpenError, get_breaker
 from maverick.research.config import ResearchSettings
 from maverick.research.providers.base import WebSearchError, WebSearchProvider
+from maverick.research.providers.scoring import (
+    FINANCIAL_DOMAINS,
+    extract_domain,
+    financial_relevance,
+    is_authoritative_source,
+)
 
 if TYPE_CHECKING:
     from exa_py.api import Result as ExaResult
@@ -70,32 +74,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _BREAKER_NAME = "exa_search"
-
-# Financial-specific domain preferences for better results.
-_FINANCIAL_DOMAINS = [
-    "sec.gov",
-    "edgar.sec.gov",
-    "investor.gov",
-    "bloomberg.com",
-    "reuters.com",
-    "wsj.com",
-    "ft.com",
-    "marketwatch.com",
-    "yahoo.com/finance",
-    "finance.yahoo.com",
-    "morningstar.com",
-    "fool.com",
-    "seekingalpha.com",
-    "investopedia.com",
-    "barrons.com",
-    "cnbc.com",
-    "nasdaq.com",
-    "nyse.com",
-    "finra.org",
-    "federalreserve.gov",
-    "treasury.gov",
-    "bls.gov",
-]
 
 # Domains to exclude for financial searches.
 _EXCLUDED_DOMAINS = [
@@ -109,41 +87,6 @@ _EXCLUDED_DOMAINS = [
     "linkedin.com",
     "youtube.com",
     "wikipedia.org",
-]
-
-_AUTHORITATIVE_DOMAINS = [
-    "sec.gov",
-    "edgar.sec.gov",
-    "federalreserve.gov",
-    "treasury.gov",
-    "bloomberg.com",
-    "reuters.com",
-    "wsj.com",
-    "ft.com",
-]
-
-_FINANCIAL_KEYWORDS = [
-    "earnings",
-    "revenue",
-    "profit",
-    "financial",
-    "quarterly",
-    "annual",
-    "sec filing",
-    "10-k",
-    "10-q",
-    "balance sheet",
-    "income statement",
-    "cash flow",
-    "dividend",
-    "market cap",
-    "valuation",
-    "analyst",
-    "forecast",
-    "guidance",
-    "ebitda",
-    "eps",
-    "pe ratio",
 ]
 
 _FINANCIAL_QUERY_TERMS = {
@@ -172,16 +115,6 @@ _CONTENT_CHARS = 2000
 _RAW_CONTENT_CHARS = 5000
 _DEFAULT_SCORE = 0.7
 
-# Financial-relevance scoring weights, verbatim from legacy.
-_DOMAIN_SCORE_TOP_TIER = 0.4
-_DOMAIN_SCORE_HIGH_QUALITY = 0.3
-_DOMAIN_SCORE_OTHER = 0.2
-_KEYWORD_SCORE_PER_MATCH = 0.05
-_KEYWORD_SCORE_MAX = 0.3
-_TITLE_SCORE = 0.1
-_RECENCY_SCORE_30D = 0.1
-_RECENCY_SCORE_90D = 0.05
-
 
 class ExaSearchProvider(WebSearchProvider):
     """Exa search provider for comprehensive web search using MCP tools with financial optimization."""
@@ -189,7 +122,7 @@ class ExaSearchProvider(WebSearchProvider):
     def __init__(self, api_key: str, *, settings: ResearchSettings | None = None):
         super().__init__(api_key, settings=settings)
         self._api_key_verified = bool(api_key)
-        self.financial_domains = list(_FINANCIAL_DOMAINS)
+        self.financial_domains = list(FINANCIAL_DOMAINS)
         self.excluded_domains = list(_EXCLUDED_DOMAINS)
         logger.info("Initialized ExaSearchProvider with financial optimization")
 
@@ -389,61 +322,18 @@ class ExaSearchProvider(WebSearchProvider):
 
     def _calculate_financial_relevance(self, result: ExaResult | Any) -> float:
         """Calculate financial relevance score for a search result (0.0 to 1.0)."""
-        score = 0.0
-
-        domain = self._extract_domain(result.url)
-        if domain in self.financial_domains:
-            if domain in ["sec.gov", "edgar.sec.gov", "federalreserve.gov"]:
-                score += _DOMAIN_SCORE_TOP_TIER
-            elif domain in ["bloomberg.com", "reuters.com", "wsj.com", "ft.com"]:
-                score += _DOMAIN_SCORE_HIGH_QUALITY
-            else:
-                score += _DOMAIN_SCORE_OTHER
-
-        if hasattr(result, "text") and result.text:
-            text_lower = result.text.lower()
-            keyword_matches = sum(
-                1 for keyword in _FINANCIAL_KEYWORDS if keyword in text_lower
-            )
-            score += min(keyword_matches * _KEYWORD_SCORE_PER_MATCH, _KEYWORD_SCORE_MAX)
-
-        if hasattr(result, "title") and result.title:
-            title_lower = result.title.lower()
-            if any(
-                term in title_lower
-                for term in ["financial", "earnings", "quarterly", "annual", "sec"]
-            ):
-                score += _TITLE_SCORE
-
-        if hasattr(result, "published_date") and result.published_date:
-            try:
-                from datetime import datetime
-
-                date_str = str(result.published_date)
-                if date_str and date_str != "":
-                    if date_str.endswith("Z"):
-                        date_str = date_str.replace("Z", "+00:00")
-
-                    pub_date = datetime.fromisoformat(date_str)
-                    days_old = (datetime.now(UTC) - pub_date).days
-
-                    if days_old <= 30:
-                        score += _RECENCY_SCORE_30D
-                    elif days_old <= 90:
-                        score += _RECENCY_SCORE_90D
-            except (ValueError, AttributeError, TypeError):
-                pass
-
-        return min(score, 1.0)
+        return financial_relevance(
+            url=result.url or "",
+            text=getattr(result, "text", None),
+            title=getattr(result, "title", None),
+            published_date=getattr(result, "published_date", None),
+            financial_domains=self.financial_domains,
+        )
 
     def _extract_domain(self, url: str) -> str:
         """Extract domain from URL."""
-        try:
-            return urlparse(url).netloc.lower().replace("www.", "")
-        except Exception:
-            return ""
+        return extract_domain(url)
 
     def _is_authoritative_source(self, url: str) -> bool:
         """Check if URL is from an authoritative financial source."""
-        domain = self._extract_domain(url)
-        return domain in _AUTHORITATIVE_DOMAINS
+        return is_authoritative_source(url)

--- a/maverick/research/providers/scoring.py
+++ b/maverick/research/providers/scoring.py
@@ -1,0 +1,154 @@
+"""Financial-relevance scoring shared by every search provider. Third-layer sibling: imports nothing from the domain.
+
+Moved out of `exa.py` so `SearXNGProvider` and `ExaSearchProvider` score and
+sort results identically. The domain lists, keyword list, and weights are
+verbatim from the legacy Exa provider. `ExaSearchProvider` keeps thin method
+wrappers around these functions so its callers and tests are unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+# Financial-specific domain preferences for better results.
+FINANCIAL_DOMAINS = [
+    "sec.gov",
+    "edgar.sec.gov",
+    "investor.gov",
+    "bloomberg.com",
+    "reuters.com",
+    "wsj.com",
+    "ft.com",
+    "marketwatch.com",
+    "yahoo.com/finance",
+    "finance.yahoo.com",
+    "morningstar.com",
+    "fool.com",
+    "seekingalpha.com",
+    "investopedia.com",
+    "barrons.com",
+    "cnbc.com",
+    "nasdaq.com",
+    "nyse.com",
+    "finra.org",
+    "federalreserve.gov",
+    "treasury.gov",
+    "bls.gov",
+]
+
+AUTHORITATIVE_DOMAINS = [
+    "sec.gov",
+    "edgar.sec.gov",
+    "federalreserve.gov",
+    "treasury.gov",
+    "bloomberg.com",
+    "reuters.com",
+    "wsj.com",
+    "ft.com",
+]
+
+FINANCIAL_KEYWORDS = [
+    "earnings",
+    "revenue",
+    "profit",
+    "financial",
+    "quarterly",
+    "annual",
+    "sec filing",
+    "10-k",
+    "10-q",
+    "balance sheet",
+    "income statement",
+    "cash flow",
+    "dividend",
+    "market cap",
+    "valuation",
+    "analyst",
+    "forecast",
+    "guidance",
+    "ebitda",
+    "eps",
+    "pe ratio",
+]
+
+_TOP_TIER_DOMAINS = ["sec.gov", "edgar.sec.gov", "federalreserve.gov"]
+_HIGH_QUALITY_DOMAINS = ["bloomberg.com", "reuters.com", "wsj.com", "ft.com"]
+_TITLE_TERMS = ["financial", "earnings", "quarterly", "annual", "sec"]
+
+# Scoring weights, verbatim from legacy.
+_DOMAIN_SCORE_TOP_TIER = 0.4
+_DOMAIN_SCORE_HIGH_QUALITY = 0.3
+_DOMAIN_SCORE_OTHER = 0.2
+_KEYWORD_SCORE_PER_MATCH = 0.05
+_KEYWORD_SCORE_MAX = 0.3
+_TITLE_SCORE = 0.1
+_RECENCY_SCORE_30D = 0.1
+_RECENCY_SCORE_90D = 0.05
+
+
+def extract_domain(url: str) -> str:
+    """Return the lowercased host of `url` without a `www.` prefix, or `""`."""
+    try:
+        return urlparse(url).netloc.lower().replace("www.", "")
+    except Exception:
+        return ""
+
+
+def is_authoritative_source(url: str) -> bool:
+    """Whether `url` is from an authoritative financial source."""
+    return extract_domain(url) in AUTHORITATIVE_DOMAINS
+
+
+def financial_relevance(
+    *,
+    url: str,
+    text: str | None,
+    title: str | None,
+    published_date: str | None,
+    financial_domains: list[str] | None = None,
+) -> float:
+    """Score a search result's financial relevance from 0.0 to 1.0.
+
+    Domain tier, keyword density in `text` (capped), a title bonus, and a
+    recency bonus for ISO `published_date` values within 30 or 90 days.
+    """
+    domains = financial_domains if financial_domains is not None else FINANCIAL_DOMAINS
+    score = 0.0
+
+    domain = extract_domain(url)
+    if domain in domains:
+        if domain in _TOP_TIER_DOMAINS:
+            score += _DOMAIN_SCORE_TOP_TIER
+        elif domain in _HIGH_QUALITY_DOMAINS:
+            score += _DOMAIN_SCORE_HIGH_QUALITY
+        else:
+            score += _DOMAIN_SCORE_OTHER
+
+    if text:
+        text_lower = text.lower()
+        keyword_matches = sum(
+            1 for keyword in FINANCIAL_KEYWORDS if keyword in text_lower
+        )
+        score += min(keyword_matches * _KEYWORD_SCORE_PER_MATCH, _KEYWORD_SCORE_MAX)
+
+    if title:
+        title_lower = title.lower()
+        if any(term in title_lower for term in _TITLE_TERMS):
+            score += _TITLE_SCORE
+
+    if published_date:
+        try:
+            date_str = str(published_date)
+            if date_str.endswith("Z"):
+                date_str = date_str.replace("Z", "+00:00")
+            pub_date = datetime.fromisoformat(date_str)
+            days_old = (datetime.now(UTC) - pub_date).days
+            if days_old <= 30:
+                score += _RECENCY_SCORE_30D
+            elif days_old <= 90:
+                score += _RECENCY_SCORE_90D
+        except (ValueError, AttributeError, TypeError):
+            pass
+
+    return min(score, 1.0)

--- a/maverick/research/providers/searxng.py
+++ b/maverick/research/providers/searxng.py
@@ -1,0 +1,207 @@
+"""SearXNG web search provider: a self-hosted, keyless backend for the research tools. Third-layer sibling: imports platform, config, and the provider base.
+
+SearXNG (https://docs.searxng.org) is a self-hosted metasearch engine with a
+JSON API at `GET {base_url}/search?q=...&format=json`. Most instances ship
+with the `json` format disabled; enabling it is a one-line change to the
+instance's `settings.yml` (`search: formats: [html, json]`). A 403 from the
+instance is reported with that instruction instead of a generic failure.
+
+Requests go through `maverick.platform.http.request_resilient`, so the shared
+per-name rate limiter, circuit breaker, and retry policy apply, with the
+breaker thresholds taken from `ResearchSettings` exactly as `exa.py` does.
+The base class's provider-level health gate runs on top. Results normalize
+to the dict shape `ExaSearchProvider` returns so the research agents cannot
+tell the backends apart; SearXNG returns snippets rather than page text, so
+`raw_content` equals `content`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from maverick.platform.config import HttpSettings, get_platform_settings
+from maverick.platform.http import CircuitOpenError, create_client, request_resilient
+from maverick.research.config import ResearchSettings
+from maverick.research.providers.base import WebSearchError, WebSearchProvider
+from maverick.research.providers.scoring import (
+    extract_domain,
+    financial_relevance,
+    is_authoritative_source,
+)
+
+logger = logging.getLogger(__name__)
+
+_BREAKER_NAME = "searxng_search"
+_CONTENT_CHARS = 2000
+_DEFAULT_SCORE = 0.7
+
+# SearXNG `time_range` values keyed by the research timeframe strings the
+# service passes around (`ResearchSettings.default_timeframe` and friends).
+_TIME_RANGES = {
+    "1d": "day",
+    "7d": "week",
+    "1w": "week",
+    "30d": "month",
+    "1m": "month",
+    "1y": "year",
+}
+
+_JSON_DISABLED_HINT = (
+    "SearXNG answered {status} to a format=json request. Enable the JSON "
+    "format on the instance: in settings.yml set `search: formats: [html, json]`."
+)
+
+
+def time_range_for(timeframe: str | None) -> str | None:
+    """Map a research timeframe (`"1m"`, `"7d"`, ...) to a SearXNG `time_range`.
+
+    Returns `None` for timeframes SearXNG cannot express (`"3m"`), in which case
+    the request omits the parameter and the instance applies no recency filter.
+    """
+    if timeframe is None:
+        return None
+    return _TIME_RANGES.get(timeframe.strip().lower())
+
+
+class SearXNGProvider(WebSearchProvider):
+    """Keyless search provider backed by a self-hosted SearXNG instance."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        settings: ResearchSettings | None = None,
+        time_range: str | None = None,
+        http_settings: HttpSettings | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        # SearXNG has no API key; the base class stores one but never reads it.
+        super().__init__("", settings=settings)
+        self.base_url = base_url.rstrip("/")
+        self.time_range = time_range
+        self._http_settings = http_settings
+        self._transport = transport
+        logger.info("Initialized SearXNGProvider for %s", self.base_url)
+
+    def _request_settings(self, timeout_seconds: float) -> HttpSettings:
+        """Per-search HTTP settings: the platform's retry and rate policy, the
+        research breaker thresholds, and the adaptive per-query timeout."""
+        base = self._http_settings or get_platform_settings().http
+        return HttpSettings(
+            timeout_seconds=timeout_seconds,
+            retries=base.retries,
+            backoff_base_seconds=base.backoff_base_seconds,
+            rate_limit_per_second=base.rate_limit_per_second,
+            breaker_failure_threshold=self._settings.search_circuit_breaker_failure_threshold,
+            breaker_recovery_seconds=self._settings.search_circuit_breaker_recovery_seconds,
+        )
+
+    async def search(
+        self, query: str, num_results: int = 10, timeout_budget: float | None = None
+    ) -> list[dict[str, Any]]:
+        """Search the instance and return results in the shared provider shape."""
+        if not self.is_healthy():
+            logger.warning("SearXNG provider is unhealthy - skipping search")
+            raise WebSearchError("SearXNG provider disabled due to repeated failures")
+
+        search_timeout = self._calculate_timeout(query, timeout_budget)
+        http_settings = self._request_settings(search_timeout)
+        params: dict[str, Any] = {
+            "q": query,
+            "format": "json",
+            "categories": "general",
+            "language": "en",
+        }
+        if self.time_range is not None:
+            params["time_range"] = self.time_range
+
+        try:
+            async with create_client(
+                http_settings, transport=self._transport
+            ) as client:
+                response = await asyncio.wait_for(
+                    request_resilient(
+                        _BREAKER_NAME,
+                        client,
+                        "GET",
+                        f"{self.base_url}/search",
+                        settings=http_settings,
+                        params=params,
+                    ),
+                    timeout=search_timeout,
+                )
+            results = self._normalize_response(response)[:num_results]
+        except TimeoutError:
+            self._record_failure("timeout")
+            raise WebSearchError(
+                f"SearXNG search timed out after {search_timeout:.1f} seconds"
+            )
+        except CircuitOpenError as e:
+            self._record_failure("error")
+            raise WebSearchError(f"SearXNG search failed: {e}") from e
+        except WebSearchError:
+            self._record_failure("error")
+            raise
+        except Exception as e:
+            self._record_failure("error")
+            raise WebSearchError(f"SearXNG search failed: {e}") from e
+
+        self._record_success()
+        return results
+
+    def _normalize_response(self, response: httpx.Response) -> list[dict[str, Any]]:
+        """Convert a SearXNG JSON response into the shared result shape."""
+        if response.status_code == 403:
+            raise WebSearchError(_JSON_DISABLED_HINT.format(status=403))
+        if response.status_code >= 400:
+            raise WebSearchError(f"SearXNG returned HTTP {response.status_code}")
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise WebSearchError(
+                _JSON_DISABLED_HINT.format(status=response.status_code)
+            ) from exc
+        items = payload.get("results", []) if isinstance(payload, dict) else []
+
+        results: list[dict[str, Any]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            url = str(item.get("url") or "")
+            title = str(item.get("title") or "No Title")
+            content = str(item.get("content") or "")[:_CONTENT_CHARS]
+            published_date = str(item.get("publishedDate") or "")
+            raw_score = item.get("score")
+            score = (
+                float(raw_score)
+                if isinstance(raw_score, int | float)
+                and not isinstance(raw_score, bool)
+                else _DEFAULT_SCORE
+            )
+            results.append(
+                {
+                    "url": url,
+                    "title": title,
+                    "content": content,
+                    "raw_content": content,
+                    "published_date": published_date,
+                    "score": score,
+                    "financial_relevance": financial_relevance(
+                        url=url,
+                        text=content,
+                        title=title,
+                        published_date=published_date or None,
+                    ),
+                    "provider": "searxng",
+                    "author": "",
+                    "domain": extract_domain(url),
+                    "is_authoritative": is_authoritative_source(url),
+                }
+            )
+
+        results.sort(key=lambda x: (x["financial_relevance"], x["score"]), reverse=True)
+        return results

--- a/maverick/research/service.py
+++ b/maverick/research/service.py
@@ -24,7 +24,7 @@ depth -- so, unlike `market_data`, the collaborator here can't be a single long-
 handed to the constructor. `AgentFactory` (`service_support.py`) is a `Protocol` called once per
 research call with the resolved `persona`/`default_depth`, returning a `ResearchRunner` (the
 structural subset of `DeepResearchAgent`'s public surface this service actually calls). The
-default factory (`_build_default_agent`) constructs a real `ExaSearchProvider` +
+default factory (`_build_default_agent`) constructs a real `ExaSearchProvider` (or `SearXNGProvider`, per `ResearchSettings.search_backend`) +
 `DeepResearchAgent`; tests inject a fake `agent_factory` that returns a scripted double, never
 touching langgraph/langchain/exa-py.
 
@@ -107,7 +107,9 @@ import uuid
 from maverick.platform.llm import LLMProvider, get_llm_settings
 from maverick.research.agents.graph import DeepResearchAgent
 from maverick.research.config import ResearchSettings, get_research_settings
+from maverick.research.providers.base import WebSearchProvider
 from maverick.research.providers.exa import ExaSearchProvider
+from maverick.research.providers.searxng import SearXNGProvider, time_range_for
 from maverick.research.service_support import (
     AgentFactory,
     build_metadata,
@@ -162,16 +164,34 @@ class ResearchService:
     def _build_default_agent(
         self, *, persona: Persona, default_depth: ResearchDepth
     ) -> DeepResearchAgent:
-        assert self._settings.exa_api_key is not None, (
-            "_build_default_agent must only run after _configuration_error confirms "
-            "exa_api_key is set"
-        )
-        exa = ExaSearchProvider(
-            self._settings.exa_api_key.get_secret_value(), settings=self._settings
-        )
+        search: WebSearchProvider
+        if self._settings.search_backend == "searxng":
+            assert self._settings.searxng_base_url is not None, (
+                "_build_default_agent must only run after _configuration_error confirms "
+                "searxng_base_url is set"
+            )
+            search = SearXNGProvider(
+                self._settings.searxng_base_url,
+                settings=self._settings,
+                time_range=time_range_for(self._settings.default_timeframe),
+            )
+        else:
+            assert self._settings.exa_api_key is not None, (
+                "_build_default_agent must only run after _configuration_error confirms "
+                "exa_api_key is set"
+            )
+            search = ExaSearchProvider(
+                self._settings.exa_api_key.get_secret_value(), settings=self._settings
+            )
         return DeepResearchAgent(
-            search_clients=[exa], persona=persona, default_depth=default_depth
+            search_clients=[search], persona=persona, default_depth=default_depth
         )
+
+    def _search_configured(self) -> bool:
+        """Whether the selected search backend has what it needs."""
+        if self._settings.search_backend == "searxng":
+            return self._settings.searxng_base_url is not None
+        return self._settings.exa_api_key is not None
 
     def _configuration_error(
         self, request_id: str, **extra: object
@@ -189,7 +209,8 @@ class ResearchService:
             problem = llm_configuration_value_error_problem(exc)
             return configuration_error(problem, request_id=request_id, **extra)
         problem = configuration_problem(
-            exa_configured=self._settings.exa_api_key is not None,
+            search_backend=self._settings.search_backend,
+            search_configured=self._search_configured(),
             llm_provider=provider.value if provider is not None else None,
             valid_llm_providers=_VALID_LLM_PROVIDERS,
         )

--- a/maverick/research/service_support.py
+++ b/maverick/research/service_support.py
@@ -124,12 +124,33 @@ def llm_configuration_value_error_problem(
 
 
 def configuration_problem(
-    *, exa_configured: bool, llm_provider: str | None, valid_llm_providers: str
+    *,
+    search_backend: str,
+    search_configured: bool,
+    llm_provider: str | None,
+    valid_llm_providers: str,
 ) -> tuple[str, dict[str, Any]] | None:
-    """Return `(message, details)` for the first missing prerequisite (Exa, then the BYOK LLM),
-    or `None` when both are configured. See `service.py`'s module docstring, "Configuration
-    errors" section."""
-    if not exa_configured:
+    """Return `(message, details)` for the first missing prerequisite (the selected
+    search backend, then the BYOK LLM), or `None` when both are configured. See
+    `service.py`'s module docstring, "Configuration errors" section."""
+    if not search_configured:
+        if search_backend == "searxng":
+            return (
+                "Research functionality unavailable - SearXNG search backend not configured",
+                {
+                    "required_configuration": (
+                        "SEARXNG_BASE_URL is required when RESEARCH_SEARCH_BACKEND=searxng"
+                    ),
+                    "searxng_base_url": (
+                        "Missing (configure SEARXNG_BASE_URL environment variable)"
+                    ),
+                    "setup_instructions": (
+                        "Point SEARXNG_BASE_URL at a SearXNG instance with the json "
+                        "format enabled (settings.yml: search.formats includes json), "
+                        "or set RESEARCH_SEARCH_BACKEND=exa with EXA_API_KEY"
+                    ),
+                },
+            )
         return (
             "Research functionality unavailable - Exa search provider not configured",
             {

--- a/server.json
+++ b/server.json
@@ -72,6 +72,18 @@
           "description": "Optional API key for Exa web search (research extra). Get at https://exa.ai",
           "isRequired": false,
           "isSecret": true
+        },
+        {
+          "name": "RESEARCH_SEARCH_BACKEND",
+          "description": "Optional research search backend: exa (default) or searxng.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "SEARXNG_BASE_URL",
+          "description": "Optional base URL of a self-hosted SearXNG instance with the JSON format enabled; used when RESEARCH_SEARCH_BACKEND=searxng.",
+          "isRequired": false,
+          "isSecret": false
         }
       ]
     },
@@ -151,6 +163,18 @@
           "description": "Optional API key for Exa web search (research extra). Get at https://exa.ai",
           "isRequired": false,
           "isSecret": true
+        },
+        {
+          "name": "RESEARCH_SEARCH_BACKEND",
+          "description": "Optional research search backend: exa (default) or searxng.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "SEARXNG_BASE_URL",
+          "description": "Optional base URL of a self-hosted SearXNG instance with the JSON format enabled; used when RESEARCH_SEARCH_BACKEND=searxng.",
+          "isRequired": false,
+          "isSecret": false
         }
       ]
     }

--- a/tests/research/test_config.py
+++ b/tests/research/test_config.py
@@ -15,6 +15,8 @@ _ENV_VARS = (
     "RESEARCH_DEFAULT_MAX_SOURCES",
     "RESEARCH_DEFAULT_TIMEFRAME",
     "RESEARCH_SENTIMENT_DEFAULT_TIMEFRAME",
+    "RESEARCH_SEARCH_BACKEND",
+    "SEARXNG_BASE_URL",
 )
 
 
@@ -103,3 +105,34 @@ def test_singleton_and_reset():
     assert get_research_settings() is a
     reset_research_settings()
     assert get_research_settings() is not a
+
+
+def test_search_backend_defaults_to_exa_with_no_searxng_url():
+    s = ResearchSettings()
+
+    assert s.search_backend == "exa"
+    assert s.searxng_base_url is None
+
+
+def test_search_backend_env_override_normalizes_the_url(monkeypatch):
+    monkeypatch.setenv("RESEARCH_SEARCH_BACKEND", "searxng")
+    monkeypatch.setenv("SEARXNG_BASE_URL", "http://localhost:8080/")
+
+    s = ResearchSettings()
+
+    assert s.search_backend == "searxng"
+    assert s.searxng_base_url == "http://localhost:8080"
+
+
+def test_invalid_search_backend_fails_fast(monkeypatch):
+    monkeypatch.setenv("RESEARCH_SEARCH_BACKEND", "bing")
+
+    with pytest.raises(ValidationError):
+        ResearchSettings()
+
+
+def test_searxng_base_url_requires_an_http_scheme(monkeypatch):
+    monkeypatch.setenv("SEARXNG_BASE_URL", "localhost:8080")
+
+    with pytest.raises(ValidationError):
+        ResearchSettings()

--- a/tests/research/test_scoring.py
+++ b/tests/research/test_scoring.py
@@ -1,0 +1,83 @@
+"""Tests for `maverick.research.providers.scoring`, the relevance helpers shared by
+every search provider."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from maverick.research.providers.scoring import (
+    extract_domain,
+    financial_relevance,
+    is_authoritative_source,
+)
+
+
+def test_extract_domain_lowercases_and_strips_www():
+    assert extract_domain("https://www.Reuters.com/markets/x") == "reuters.com"
+
+
+def test_extract_domain_of_empty_input_is_empty():
+    assert extract_domain("") == ""
+
+
+def test_authoritative_source_matches_the_domain_list():
+    assert is_authoritative_source("https://www.sec.gov/edgar") is True
+    assert is_authoritative_source("https://example.com") is False
+
+
+def test_financial_relevance_tiers_domains():
+    def score(url: str) -> float:
+        return financial_relevance(url=url, text=None, title=None, published_date=None)
+
+    assert score("https://sec.gov/x") == pytest.approx(0.4)
+    assert score("https://reuters.com/x") == pytest.approx(0.3)
+    assert score("https://fool.com/x") == pytest.approx(0.2)
+    assert score("https://example.com/x") == pytest.approx(0.0)
+
+
+def test_financial_relevance_caps_keyword_bonus_and_adds_title_bonus():
+    text = "earnings revenue profit dividend valuation analyst forecast guidance"
+    score = financial_relevance(
+        url="https://example.com",
+        text=text,
+        title="Quarterly earnings",
+        published_date=None,
+    )
+    # Eight keyword hits cap at 0.3; the title term adds 0.1.
+    assert score == pytest.approx(0.4)
+
+
+def test_financial_relevance_recency_bonus():
+    recent = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+    older = (datetime.now(UTC) - timedelta(days=60)).isoformat()
+    assert financial_relevance(
+        url="https://example.com", text=None, title=None, published_date=recent
+    ) == pytest.approx(0.1)
+    assert financial_relevance(
+        url="https://example.com", text=None, title=None, published_date=older
+    ) == pytest.approx(0.05)
+
+
+def test_financial_relevance_ignores_unparseable_dates():
+    assert (
+        financial_relevance(
+            url="https://example.com",
+            text=None,
+            title=None,
+            published_date="not a date",
+        )
+        == 0.0
+    )
+
+
+def test_financial_relevance_honors_a_custom_domain_list():
+    score = financial_relevance(
+        url="https://example.com/x",
+        text=None,
+        title=None,
+        published_date=None,
+        financial_domains=["example.com"],
+    )
+    assert score == pytest.approx(0.2)

--- a/tests/research/test_searxng.py
+++ b/tests/research/test_searxng.py
@@ -1,0 +1,235 @@
+"""Tests for `maverick.research.providers.searxng`. No network: every request is
+answered by an `httpx.MockTransport` handed to the provider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from maverick.platform.config import HttpSettings
+from maverick.research.config import ResearchSettings
+from maverick.research.providers.base import WebSearchError
+from maverick.research.providers.searxng import SearXNGProvider, time_range_for
+
+# No retries, no backoff sleeps, no rate limiting: these tests cover the
+# provider's own behavior, not the platform resilience policy.
+_FAST_HTTP = HttpSettings(
+    retries=0, backoff_base_seconds=0.0, rate_limit_per_second=1000.0
+)
+
+
+def _provider(handler: Any, **kwargs: Any) -> SearXNGProvider:
+    kwargs.setdefault("settings", ResearchSettings())
+    return SearXNGProvider(
+        "http://searx.local:8080/",
+        http_settings=_FAST_HTTP,
+        transport=httpx.MockTransport(handler),
+        **kwargs,
+    )
+
+
+def _json(payload: dict[str, Any], status: int = 200) -> httpx.Response:
+    return httpx.Response(status, json=payload)
+
+
+def test_time_range_mapping():
+    assert time_range_for("1d") == "day"
+    assert time_range_for("7d") == "week"
+    assert time_range_for("1w") == "week"
+    assert time_range_for("30d") == "month"
+    assert time_range_for("1m") == "month"
+    assert time_range_for("1y") == "year"
+    assert time_range_for("3m") is None
+    assert time_range_for(None) is None
+
+
+async def test_search_sends_json_format_and_normalizes_results():
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["params"] = dict(request.url.params)
+        return _json(
+            {
+                "results": [
+                    {
+                        "url": "https://example.com/a",
+                        "title": "A",
+                        "content": "plain",
+                        "publishedDate": "",
+                        "score": 0.5,
+                    },
+                    {
+                        "url": "https://www.sec.gov/filing",
+                        "title": "Quarterly earnings",
+                        "content": "revenue and earnings",
+                        "score": 0.2,
+                    },
+                ]
+            }
+        )
+
+    provider = _provider(handler, time_range="month")
+
+    results = await provider.search("AAPL earnings", num_results=10)
+
+    assert captured["path"] == "/search"
+    assert captured["params"] == {
+        "q": "AAPL earnings",
+        "format": "json",
+        "categories": "general",
+        "language": "en",
+        "time_range": "month",
+    }
+    # Sorted by financial relevance: the SEC filing (domain tier + keywords +
+    # title term) outranks the plain result despite its lower raw score.
+    assert [r["url"] for r in results] == [
+        "https://www.sec.gov/filing",
+        "https://example.com/a",
+    ]
+    sec, plain = results
+    assert sec["provider"] == "searxng"
+    assert sec["domain"] == "sec.gov"
+    assert sec["is_authoritative"] is True
+    assert sec["content"] == sec["raw_content"] == "revenue and earnings"
+    assert sec["score"] == 0.2
+    assert sec["financial_relevance"] == pytest.approx(0.6)
+    assert plain["score"] == 0.5
+    assert plain["author"] == ""
+    assert plain["published_date"] == ""
+    assert provider.is_healthy() is True
+    assert provider._failure_count == 0
+
+
+async def test_search_defaults_missing_fields():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _json({"results": [{"url": "https://example.com/x"}]})
+
+    results = await _provider(handler).search("q")
+
+    assert results == [
+        {
+            "url": "https://example.com/x",
+            "title": "No Title",
+            "content": "",
+            "raw_content": "",
+            "published_date": "",
+            "score": 0.7,
+            "financial_relevance": 0.0,
+            "provider": "searxng",
+            "author": "",
+            "domain": "example.com",
+            "is_authoritative": False,
+        }
+    ]
+
+
+async def test_search_truncates_to_num_results_and_content_length():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _json(
+            {
+                "results": [
+                    {"url": f"https://example.com/{i}", "content": "x" * 3000}
+                    for i in range(5)
+                ]
+            }
+        )
+
+    results = await _provider(handler).search("q", num_results=2)
+
+    assert len(results) == 2
+    assert len(results[0]["content"]) == 2000
+
+
+async def test_search_omits_time_range_when_none():
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return _json({"results": []})
+
+    await _provider(handler, time_range=None).search("q")
+
+    assert "time_range" not in captured["params"]
+
+
+async def test_forbidden_explains_how_to_enable_json():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="Forbidden")
+
+    provider = _provider(handler)
+
+    with pytest.raises(WebSearchError, match=r"formats: \[html, json\]"):
+        await provider.search("q")
+    assert provider._failure_count == 1
+
+
+async def test_non_json_body_is_reported_with_the_hint():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="<html>search page</html>")
+
+    with pytest.raises(WebSearchError, match="format=json"):
+        await _provider(handler).search("q")
+
+
+async def test_other_http_errors_name_the_status():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="nope")
+
+    with pytest.raises(WebSearchError, match="HTTP 404"):
+        await _provider(handler).search("q")
+
+
+async def test_transport_error_wraps_into_web_search_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    provider = _provider(handler)
+
+    with pytest.raises(WebSearchError, match="SearXNG search failed"):
+        await provider.search("q")
+    assert provider._failure_count == 1
+    assert provider.is_healthy() is True
+
+
+async def test_provider_disables_itself_after_repeated_failures():
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ConnectError("refused")
+
+    provider = _provider(handler)
+
+    for _ in range(6):  # base.py's _MAX_NON_TIMEOUT_FAILURES
+        with pytest.raises(WebSearchError):
+            await provider.search("q")
+    assert provider.is_healthy() is False
+
+    with pytest.raises(WebSearchError, match="disabled due to repeated failures"):
+        await provider.search("q")
+    assert calls == 6
+
+
+async def test_open_circuit_breaker_short_circuits_subsequent_calls():
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ConnectError("refused")
+
+    settings = ResearchSettings(
+        search_circuit_breaker_failure_threshold=1,
+        search_circuit_breaker_recovery_seconds=9999.0,
+    )
+    provider = _provider(handler, settings=settings)
+
+    with pytest.raises(WebSearchError, match="SearXNG search failed"):
+        await provider.search("first")
+    with pytest.raises(WebSearchError, match="SearXNG search failed"):
+        await provider.search("second")
+    assert calls == 1

--- a/tests/research/test_service.py
+++ b/tests/research/test_service.py
@@ -502,3 +502,79 @@ async def test_run_comprehensive_no_warning_when_well_under_budget(configured_ll
     assert isinstance(result, ComprehensiveResearchResult)
     assert result.research_metadata.timeout_warning is False
     assert result.warning is None
+
+
+# ---------------------------------------------------------------------------
+# Search backend selection (SearXNG, #186)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_comprehensive_errors_when_searxng_not_configured(configured_llm):
+    service = ResearchService(settings=ResearchSettings(search_backend="searxng"))
+
+    result = await service.run_comprehensive("AAPL outlook")
+
+    assert isinstance(result, ResearchError)
+    assert result.error_type == "not_configured"
+    assert "SearXNG search backend not configured" in result.error
+    assert result.model_extra is not None
+    assert result.model_extra["details"]["searxng_base_url"].startswith("Missing")
+
+
+async def test_searxng_backend_does_not_require_an_exa_key(configured_llm):
+    service = ResearchService(
+        settings=_configured_settings(
+            exa_api_key=None,
+            search_backend="searxng",
+            searxng_base_url="http://searx.local:8080",
+        ),
+        agent_factory=lambda **_kw: FakeAgent(report=_fixture_report()),
+    )
+
+    result = await service.run_comprehensive("AAPL outlook")
+
+    assert not isinstance(result, ResearchError)
+
+
+async def test_default_agent_factory_picks_the_searxng_provider(monkeypatch):
+    # Compare against the class object the service module holds: another test
+    # re-imports the provider modules, so a fresh import here could be a copy.
+    from maverick.research import service as service_module
+
+    captured: dict[str, Any] = {}
+
+    class _StubAgent:
+        def __init__(self, *, search_clients, persona, default_depth) -> None:
+            captured["clients"] = search_clients
+
+    monkeypatch.setattr("maverick.research.service.DeepResearchAgent", _StubAgent)
+    service = ResearchService(
+        settings=ResearchSettings(
+            search_backend="searxng", searxng_base_url="http://searx.local:8080"
+        )
+    )
+
+    service._build_default_agent(persona="moderate", default_depth="basic")
+
+    (client,) = captured["clients"]
+    assert isinstance(client, service_module.SearXNGProvider)
+    assert client.base_url == "http://searx.local:8080"
+    assert client.time_range == "month"  # default_timeframe "1m"
+
+
+async def test_default_agent_factory_picks_exa_by_default(monkeypatch):
+    from maverick.research import service as service_module
+
+    captured: dict[str, Any] = {}
+
+    class _StubAgent:
+        def __init__(self, *, search_clients, persona, default_depth) -> None:
+            captured["clients"] = search_clients
+
+    monkeypatch.setattr("maverick.research.service.DeepResearchAgent", _StubAgent)
+    service = ResearchService(settings=_configured_settings())
+
+    service._build_default_agent(persona="moderate", default_depth="basic")
+
+    (client,) = captured["clients"]
+    assert isinstance(client, service_module.ExaSearchProvider)


### PR DESCRIPTION
Closes #186.

- `SearXNGProvider` on the platform HTTP seam (rate limiter, breaker, retry), keyless, JSON API, results normalized to the Exa shape; a 403 from an instance with the json format disabled is reported with the settings.yml fix.
- `RESEARCH_SEARCH_BACKEND=exa|searxng` and `SEARXNG_BASE_URL` settings; the service builds the selected provider and the not-configured error names the right variable.
- Financial-relevance scoring lifted into `providers/scoring.py`, shared by both providers.
- Stubbed-HTTP tests only; docs, .env.example, README, and server.json updated (server.json validated against the registry schema).

https://claude.ai/code/session_01SQFYuZqoU2U7CoML32cf2L
