### PR TITLE
release: prepare v1.1.0

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -43,6 +43,7 @@ Status labels:
 | `generated/registry/pulsemcp.md` | current | docs | PulseMCP submission draft (submission mechanism unconfirmed). |
 | `generated/registry/mcp-so.md` | current | docs | mcp.so submission draft. |
 | `generated/registry/smithery.yaml` | current | docs | Smithery config draft (YAML, not scanned by the docs-catalog checker; listed here for completeness). |
+| `generated/release-notes/v1.1.0.md` | current | engineering | Release notes for v1.1.0 (used by `gh release create --notes-file`). |
 | `QUALITY_SCORE.md` | current | engineering | Per-area quality grades. |
 | `RELIABILITY.md` | current | engineering | Reliability state and gaps. |
 | `SECURITY.md` | current | engineering | Engineering security posture. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@ rather than the whole knowledge base up front.
   Registry, GHCR, third-party registries, `.mcpb` release asset); owner-run.
 - `generated/registry/README.md` - ready-to-paste registry submission
   drafts (Docker MCP Catalog, Smithery, Glama, PulseMCP, mcp.so).
+- `generated/release-notes/v1.1.0.md` - release notes for v1.1.0.
 
 ## Modernization
 

--- a/docs/generated/release-notes/v1.1.0.md
+++ b/docs/generated/release-notes/v1.1.0.md
@@ -1,0 +1,48 @@
+## maverick-mcp-server v1.1.0
+
+The first release published end to end by the tag-triggered workflow: PyPI,
+the official MCP Registry, and the GHCR image.
+
+### Fixes (backtesting)
+
+Three bugs reported and fixed by @A1-NWS-Dev1:
+
+- `backtesting_backtest_portfolio` reported the mildest constituent drawdown
+  as the portfolio `max_drawdown`; it now reports the worst (#245, #242).
+- `backtesting_create_strategy_ensemble` built SMA-crossover variants for
+  `"rsi"` and `"macd"` and collapsed the ensemble onto one `"SMA Crossover"`
+  key; each member now runs its own signal logic under its own template name
+  (#246, #243). Result keys are template display names such as
+  `"RSI Mean Reversion"`.
+- `backtesting_analyze_market_regimes` could report `method: "hmm"` and a
+  fabricated uniform probability vector after a silent fallback; it now
+  reports `method: "threshold"` when it falls back and returns one-hot
+  probabilities in that case. `method="hmm"` fits a Gaussian mixture, not a
+  Hidden Markov Model; the name is kept for compatibility (#247, #244).
+
+### FastMCP 4
+
+The server runs on FastMCP 4 (MCP Python SDK v2). Over HTTP it serves the
+`2026-07-28` protocol revision alongside `2025-11-25`; over stdio the SDK
+serves the `2025-11-25` handshake revision (#235, #258). Tool annotations are
+declared with SDK v2 field names; the wire format is unchanged.
+`fastmcp>=4.0.3` is the new floor; the direct `mcp` dependency is gone.
+
+### SearXNG research backend
+
+Research can run against a self-hosted SearXNG instance instead of Exa, with
+no API key: set `RESEARCH_SEARCH_BACKEND=searxng` and `SEARXNG_BASE_URL`
+(#186, requested by @Josephur). The instance must enable the JSON format;
+see `docs/features/deep-research.md`.
+
+### Dependencies
+
+langchain-anthropic 1.7.0, redis 8.1.0, greenlet 3.5.5, uvicorn 0.52.4,
+nltk 3.10.3 (dev only, security fixes).
+
+### Install
+
+```bash
+uvx --from maverick-mcp-server==1.1.0 maverick-mcp --transport stdio
+pip install "maverick-mcp-server[backtesting,research]==1.1.0"
+```

--- a/docs/runbooks/releasing.md
+++ b/docs/runbooks/releasing.md
@@ -13,8 +13,8 @@ The canonical server identity across every step is `io.github.wshobson/maverick-
 provenance comment the official registry uses to verify PyPI/repo ownership,
 and `server.json` declares the package/transport surface registries read.
 
-v1.0.0 is already tagged and released on GitHub
-(`gh release list` shows `v1.0.0`). The steps below take that release the
+v1.0.0 was released on GitHub only and never reached PyPI. v1.1.0 is the
+first tag the publish workflow carries end to end. The steps below take that release the
 rest of the way to installable-by-everyone.
 
 ## Sequence overview
@@ -25,7 +25,7 @@ rest of the way to installable-by-everyone.
 3. GHCR image push (independent of steps 1-2; can happen any time).
 4. Third-party registry submissions (Docker MCP Catalog, Smithery, Glama,
    PulseMCP, mcp.so).
-5. Attach the `.mcpb` bundle to the v1.0.0 GitHub release.
+5. Attach the `.mcpb` bundle to the v1.1.0 GitHub release.
 
 Steps 1 and 3 are independent of each other. Step 2 needs step 1 done first.
 Step 4 can happen any time after step 1 (most third-party catalogs just want
@@ -41,7 +41,7 @@ project, or an account-wide token for the first publish since the project
 doesn't exist on PyPI yet).
 
 **Reversible?** No. A version number published to PyPI can never be reused,
-even if yanked. Publishing 1.0.0 is a one-time, permanent action.
+even if yanked. Publishing 1.1.0 is a one-time, permanent action.
 
 ### Option A: trusted publishing + tag push (once `publish.yml` exists)
 
@@ -51,9 +51,9 @@ even if yanked. Publishing 1.0.0 is a one-time, permanent action.
    - Repository: `maverick-mcp`
    - Workflow: `publish.yml`
    - Environment: leave blank unless the workflow defines one.
-2. Push (or re-push) the `v1.0.0` tag so the workflow's tag trigger fires:
+2. Push (or re-push) the `v1.1.0` tag so the workflow's tag trigger fires:
    ```bash
-   git push origin v1.0.0
+   git push origin v1.1.0
    ```
 3. Watch the run: `gh run watch --repo wshobson/maverick-mcp`.
 
@@ -81,7 +81,7 @@ uvx maverick-mcp-server --help
 pip install "maverick-mcp-server[backtesting,research]"
 ```
 
-Then edit the v1.0.0 GitHub release notes to remove any "install from source
+Then edit the v1.1.0 GitHub release notes to remove any "install from source
 until published" phrasing and state real PyPI availability.
 
 ## Step 2: official MCP Registry publish
@@ -125,8 +125,8 @@ GHCR, but once pulled by others the image content is out in the world.
 
 ```bash
 docker login ghcr.io -u wshobson
-docker build -t ghcr.io/wshobson/maverick-mcp:1.0.0 -t ghcr.io/wshobson/maverick-mcp:latest .
-docker push ghcr.io/wshobson/maverick-mcp:1.0.0
+docker build -t ghcr.io/wshobson/maverick-mcp:1.1.0 -t ghcr.io/wshobson/maverick-mcp:latest .
+docker push ghcr.io/wshobson/maverick-mcp:1.1.0
 docker push ghcr.io/wshobson/maverick-mcp:latest
 ```
 
@@ -135,7 +135,7 @@ The Dockerfile must carry the
 before this step (Phase 9, Task 2). Verify the image runs:
 
 ```bash
-docker run --rm ghcr.io/wshobson/maverick-mcp:1.0.0 --help
+docker run --rm ghcr.io/wshobson/maverick-mcp:1.1.0 --help
 ```
 
 ### Follow-up: add the Docker package entry to server.json
@@ -154,7 +154,7 @@ package entry like:
   "registry_type": "oci",
   "registry_base_url": "https://ghcr.io",
   "identifier": "wshobson/maverick-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "transport": { "type": "stdio" }
 }
 ```
@@ -195,7 +195,7 @@ delisting on request but there is no self-service undo for most of these.
 make bundle   # builds dist/maverick-mcp.mcpb (thin bundle: launches the
               # PyPI package via uvx; requires uv + the PyPI publish first)
 npx @anthropic-ai/mcpb validate dist/manifest.json  # official validator
-gh release upload v1.0.0 dist/maverick-mcp.mcpb
+gh release upload v1.1.0 dist/maverick-mcp.mcpb
 ```
 
 The bundle vendors no code -- its manifest launches

--- a/docs/runbooks/releasing.md
+++ b/docs/runbooks/releasing.md
@@ -50,7 +50,10 @@ even if yanked. Publishing 1.1.0 is a one-time, permanent action.
    - Owner: `wshobson`
    - Repository: `maverick-mcp`
    - Workflow: `publish.yml`
-   - Environment: leave blank unless the workflow defines one.
+   - Environment: `pypi`. The workflow's `publish-pypi` job runs inside the
+     GitHub environment named `pypi`, so the publisher must name it; a
+     blank environment does not match and PyPI rejects the run as
+     `invalid-publisher`.
 2. Push (or re-push) the `v1.1.0` tag so the workflow's tag trigger fires:
    ```bash
    git push origin v1.1.0

--- a/maverick/__init__.py
+++ b/maverick/__init__.py
@@ -5,4 +5,4 @@ docs/design-docs/2026-07-18-mcp-modernization.md. Import contracts forbid
 importing the legacy maverick_mcp package from here.
 """
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maverick-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 description = "Personal-use MCP server for Claude Desktop providing professional-grade stock analysis and technical indicators"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/wshobson/maverick-mcp",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "maverick-mcp-server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -89,8 +89,8 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/wshobson/maverick-mcp:1.0.0",
-      "version": "1.0.0",
+      "identifier": "ghcr.io/wshobson/maverick-mcp:1.1.0",
+      "version": "1.1.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/structure/test_package.py
+++ b/tests/structure/test_package.py
@@ -4,4 +4,4 @@
 def test_version_is_importable():
     import maverick
 
-    assert maverick.__version__ == "1.0.0.dev0"
+    assert maverick.__version__ == "1.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2374,7 +2374,7 @@ wheels = [
 
 [[package]]
 name = "maverick-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Version 1.1.0 in pyproject, the package, server.json, and the structure test; release notes under docs/generated/release-notes; the release runbook generalized from v1.0.0. No tag is pushed by this PR; the tag and the publish steps are owner-gated.

https://claude.ai/code/session_01SQFYuZqoU2U7CoML32cf2L